### PR TITLE
Change Dict Syntax to Julia 0.4

### DIFF
--- a/src/estspec.jl
+++ b/src/estspec.jl
@@ -30,12 +30,12 @@ function smooth(x::Array, window_len::Int=7, window::String="hanning")
         println("Window length must be odd, reset to $window_len")
     end
 
-    windows = {"hanning" => DSP.hanning,
+    windows = @compat Dict("hanning" => DSP.hanning,
                "hamming" => DSP.hamming,
                "bartlett" => DSP.bartlett,
                "blackman" => DSP.blackman,
                "flat" => DSP.rect  # moving average
-               }
+               )
 
     # Reflect x around x[0] and x[-1] prior to convolution
     k = int(window_len / 2)


### PR DESCRIPTION
This is my first attempt at using the pull request feature on GitHub, so I'm not entirely sure I'm doing the right thing!?

In any case, I'm running some code on Julia 0.4 and get deprecation warnings because of the dict syntax. The solution seems to be to replace the "{... => ...}" syntax with "Dict(... => ...)". However, as this won't work in Julia <0.4, this change also means that a REQUIRE should be added for Compat.jl
