### PR TITLE
Add `solve_vf`, `solve_pf`, `solve_both` methods and an `AbstractModel` type

### DIFF
--- a/examples/jv_test.jl
+++ b/examples/jv_test.jl
@@ -1,4 +1,5 @@
 using QuantEcon
+using QuantEcon.Models
 using PyPlot
 
 wp = JvWorker(grid_size=25)

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -9,8 +9,46 @@ using Distributions
 using Optim: optimize
 using Grid: CoordInterpGrid, BCnan, BCnearest, InterpLinear
 
+abstract AbstractModel
+
+"""
+Generic function to solve model via value function iteration.
+
+For this function to work
+"""
+
+function solve_vf(m::AbstractModel; kwargs...)
+    # make sure init_values is defined. If not provide a decent error message
+    T_model = typeof(m)
+    if !method_exists(init_values, (T_model,))
+        e = "init_values(m::$(T_model) must be defined to use default solver"
+        error(e)
+    end
+    init = init_values(m)
+
+    # hand off to routine that takes initial values as argument
+    solve_vf(m, init; kwargs...)
+end
+
+function solve_vf(m::AbstractModel, init; kwargs...)
+    # make sure bellman_operator is defined
+
+    T_model = typeof(m)
+    T_init = typeof(init)
+    if !method_exists(bellman_operator, (T_model, typeof(init)))
+        e = "bellman_operator(m::$(T_model), x::$(T_init))"
+        e *= " must be defined to use default solver"
+        error(e)
+    end
+
+    # solve this thing!
+    f(x) = bellman_operator(m, x)
+    compute_fixed_point(f, init; kwargs...)
+end
+
 export
 # types
+    AbstractModel,
     AssetPrices,
     CareerWorkerProblem,
     ConsumerProblem,
@@ -25,7 +63,8 @@ export
     coleman_operator, init_values,         # ifp
     compute_lt_price, lucas_operator,      # lucastree
     res_wage_operator,                     # odu
-    bellman_operator, bellman_operator!    # career, ifp, jv, odu, optgrowth
+    bellman_operator, bellman_operator!,   # career, ifp, jv, odu, optgrowth
+    solve_vf                               # career, ifp, jv, odu, optgrowth
 
 include("models/asset_pricing.jl")
 include("models/career.jl")

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -14,7 +14,11 @@ abstract AbstractModel
 """
 Generic function to solve model via value function iteration.
 
-For this function to work
+For this function to work the model must have implemented the following:
+
+* `init_values(m::T)`, where `T <: AbstractModel` is the model's type
+* `bellman_operator(m::T, a::S)`, where `S` is the type returned from
+   init_values
 """
 
 function solve_vf(m::AbstractModel; kwargs...)
@@ -46,6 +50,23 @@ function solve_vf(m::AbstractModel, init; kwargs...)
     compute_fixed_point(f, init; kwargs...)
 end
 
+solve_pf(m::AbstractModel; kwargs...) = get_greedy(m, solve_vf(m; kwargs...))
+function solve_pf(m::AbstractModel, init; kwargs...)
+    get_greedy(m, init, solve_vf(m, init; kwargs...))
+end
+
+function solve_both(m::AbstractModel; kwargs...)
+    vf = solve_vf(m; kwargs...)
+    pf = get_greedy(m, vf)
+    (vf, pf)
+end
+
+function solve_both(m::AbstractModel, init; kwargs...)
+    vf = solve_vf(m, init; kwargs...)
+    pf = get_greedy(m, vf)
+    (vf, pf)
+end
+
 export
 # types
     AbstractModel,
@@ -64,7 +85,7 @@ export
     compute_lt_price, lucas_operator,      # lucastree
     res_wage_operator,                     # odu
     bellman_operator, bellman_operator!,   # career, ifp, jv, odu, optgrowth
-    solve_vf                               # career, ifp, jv, odu, optgrowth
+    solve_vf, solve_pf, solve_both         # career, ifp, jv, odu, optgrowth
 
 include("models/asset_pricing.jl")
 include("models/career.jl")

--- a/src/compute_fp.jl
+++ b/src/compute_fp.jl
@@ -23,6 +23,7 @@ http://quant-econ.net/dp_intro.html
 =#
 function compute_fixed_point(T::Function, v; err_tol=1e-3, max_iter=50,
                              verbose=true, print_skip=10)
+    t = time()
     iterate = 0
     err = err_tol + 1
     while iterate < max_iter && err > err_tol
@@ -31,7 +32,10 @@ function compute_fixed_point(T::Function, v; err_tol=1e-3, max_iter=50,
         err = Base.maxabs(new_v - v)
         if verbose
             if iterate % print_skip == 0
-                println("Compute iterate $iterate with error $err")
+                tot_time = time() - t
+                msg = @sprintf "Compute iterate %i with error %2.3e" iterate err
+                msg *= @sprintf " (total time elapsed: %3.3f seconds)" tot_time
+                println(msg)
             end
         end
         v = new_v

--- a/src/models/asset_pricing.jl
+++ b/src/models/asset_pricing.jl
@@ -17,7 +17,7 @@ Simple port of the file quantecon.models.asset_pricing.py
 http://quant-econ.net/markov_asset.html
 =#
 
-type AssetPrices
+type AssetPrices <: AbstractModel
     bet::Real
     P::Matrix
     s::Vector

--- a/src/models/career.jl
+++ b/src/models/career.jl
@@ -15,7 +15,7 @@ http://quant-econ.net/career.html
 =#
 
 
-type CareerWorkerProblem
+type CareerWorkerProblem <: AbstractModel
     beta::Real
     N::Int
     B::Real
@@ -97,3 +97,6 @@ end
 function get_greedy(cp::CareerWorkerProblem, v::Array)
     bellman_operator(cp, v, ret_policy=true)
 end
+
+# Initial condition for CareerWorkerProblem. See lecture for details
+init_values(m::CareerWorkerProblem) = fill(100.0, m.N, m.N)

--- a/src/models/ifp.jl
+++ b/src/models/ifp.jl
@@ -17,7 +17,7 @@ http://quant-econ.net/ifp.html
 # @pyimport scipy.optimize as opt
 # brentq = opt.brentq
 
-type ConsumerProblem
+type ConsumerProblem <: AbstractModel
     u::Function
     du::Function
     r::Real
@@ -161,4 +161,11 @@ function init_values(cp::ConsumerProblem)
     end
 
     return V, c
+end
+
+# Special solve function for ConsumerProblem to use more efficient
+# coleman_operator
+function solve_vf(m::ConsumerProblem, init=init_values(m)[2]; kwargs...)
+    f(x) = coleman_operator(m, x)
+    compute_fixed_point(f, init; kwargs...)
 end

--- a/src/models/jv.jl
+++ b/src/models/jv.jl
@@ -23,7 +23,7 @@ http://quant-econ.net/jv.html
 
 epsilon = 1e-4  # a small number, used in optimization routine
 
-type JvWorker
+type JvWorker <: AbstractModel
     A::Real
     alpha::Real
     bet::Real
@@ -177,3 +177,6 @@ end
 function get_greedy(jv::JvWorker, V::Vector; brute_force=true)
     bellman_operator(jv, V, ret_policies=true)
 end
+
+# Initial condition for JvWorker. See lecture for details
+init_values(m::JvWorker) = [m.x_grid * 0.5]

--- a/src/models/lucastree.jl
+++ b/src/models/lucastree.jl
@@ -26,12 +26,10 @@ References
 Simple port of the file quantecon.models.lucastree.py
 
 http://quant-econ.net/markov_asset.html
-
-TODO: refactor. Python is much cleaner.
 =#
 
 
-type LucasTree
+type LucasTree <: AbstractModel
     gam::Real
     bet::Real
     alpha::Real

--- a/src/models/odu.jl
+++ b/src/models/odu.jl
@@ -13,7 +13,7 @@ References
 http://quant-econ.net/odu.html
 
 =#
-type SearchProblem
+type SearchProblem <: AbstractModel
     bet::Real
     c::Real
     F::Distribution
@@ -149,4 +149,14 @@ function res_wage_operator(sp::SearchProblem, phi::Vector)
     out = similar(phi)
     res_wage_operator!(sp, phi, out)
     return out
+end
+
+# Initial condition for SearchProblem. See lecture for details
+init_values(m::SearchProblem) = ones(m.n_pi)
+
+# Special solve function for SearchProblem b/c it doesn't implement
+# bellman_operator
+function solve_vf(m::SearchProblem, init=init_values(m); kwargs...)
+    f(x) = res_wage_operator(m, x)
+    compute_fixed_point(f, init; kwargs...)
 end

--- a/src/models/optgrowth.jl
+++ b/src/models/optgrowth.jl
@@ -22,7 +22,7 @@ http://quant-econ.net/dp_intro.html
 
     See the constructor below for details
 =#
-type GrowthModel
+type GrowthModel <: AbstractModel
     f::Function
     bet::Real
     u::Function
@@ -83,3 +83,6 @@ function get_greedy!(g::GrowthModel, w::Vector, out::Vector)
 end
 
 get_greedy(g::GrowthModel, w::Vector) = bellman_operator(g, w, ret_policy=true)
+
+# Initial condition for GrowthModel. See lecture for details
+init_values(g::GrowthModel) = 5 .* g.u([g.grid]) .- 25

--- a/test/test_models.jl
+++ b/test/test_models.jl
@@ -156,6 +156,15 @@ function set_up_data(gm::GrowthModel)
 end
 
 
+function solve_vf_runs(m::AbstractModel)
+    try
+        solve_vf(m, err_tol=Inf, verbose=false)
+        return true
+    catch
+        return false
+    end
+end
+
 facts("Testing asset_pricing.jl") do
     n = 5
     P = 0.0125 .* ones(n, n)
@@ -201,6 +210,10 @@ facts("Testing asset_pricing.jl") do
         w_bars = call_option(ap, ζ, p_s, [5, 7])[2]
         @fact length(w_bars) => 2
     end
+
+    context("Test solve_vf doesn't run") do
+        @fact solve_vf_runs(ap) => false
+    end
 end  # facts
 
 facts("Testing career.jl") do
@@ -228,6 +241,10 @@ facts("Testing career.jl") do
             @fact greedy[end, end] => 1
         end
     end
+
+    context("Test solve_vf runs") do
+        @fact solve_vf_runs(cp) => true
+    end
 end  # facts
 
 facts("Testing ifp.jl") do
@@ -248,6 +265,10 @@ facts("Testing ifp.jl") do
     shapes = (length(cp.asset_grid), length(cp.z_vals))
     @fact size(v_init) => shapes
     @fact size(c_init) => shapes
+
+    context("Test solve_vf runs") do
+        @fact solve_vf_runs(cp) => true
+    end
 end  # facts
 
 facts("Testing jv.jl") do
@@ -274,6 +295,10 @@ facts("Testing jv.jl") do
 
     # solution to bellman is fixed point
     @fact v_star => roughly(bellman_operator(jv, v_star); atol=1e-6)
+
+    context("Test solve_vf runs") do
+        @fact solve_vf_runs(jv) => true
+    end
 end  # facts
 
 facts("Testing lucastree.jl") do
@@ -309,6 +334,10 @@ facts("Testing lucastree.jl") do
 
     context("test prices increasing in y") do
         @fact prices => sort(prices)
+    end
+
+    context("Test solve_vf doesn't run") do
+        @fact solve_vf_runs(lt) => false
     end
 end  # facts
 
@@ -359,6 +388,10 @@ facts("Testing odu.jl") do
 
     # phi_pfi fixed_point?
     @fact phi_pfi => roughly(res_wage_operator(sp, phi_pfi); atol=1e-5)
+
+    context("Test solve_vf runs") do
+        @fact solve_vf_runs(sp) => true
+    end
 end  # facts
 
 facts("Testing optgrowth.jl") do
@@ -394,6 +427,10 @@ facts("Testing optgrowth.jl") do
     # test v_star fixed point.
     @fact v_star[2:end] => roughly(bellman_operator(gm, v_star)[2:end];
                                    atol=5e-2)
+
+    context("Test solve_vf runs") do
+        @fact solve_vf_runs(gm) => true
+    end
 end  # facts
 
 

--- a/test/test_models.jl
+++ b/test/test_models.jl
@@ -137,6 +137,7 @@ function set_up_data(sp::SearchProblem)
     return v_star, phi_vfi, phi_pfi
 end
 
+
 function set_up_data(gm::GrowthModel)
     f = get_data_file()
 
@@ -156,7 +157,7 @@ function set_up_data(gm::GrowthModel)
 end
 
 
-function solve_vf_runs(m::AbstractModel)
+function _f_runs(m::AbstractModel, f::Function)
     try
         solve_vf(m, err_tol=Inf, verbose=false)
         return true
@@ -164,6 +165,10 @@ function solve_vf_runs(m::AbstractModel)
         return false
     end
 end
+
+solve_vf_runs(m::AbstractModel) = _f_runs(m, solve_vf)
+solve_pf_runs(m::AbstractModel) = _f_runs(m, solve_vf)
+solve_both_runs(m::AbstractModel) = _f_runs(m, solve_both)
 
 facts("Testing asset_pricing.jl") do
     n = 5
@@ -211,8 +216,10 @@ facts("Testing asset_pricing.jl") do
         @fact length(w_bars) => 2
     end
 
-    context("Test solve_vf doesn't run") do
+    context("Test solve_(vf|pf|both) doesn't run") do
         @fact solve_vf_runs(ap) => false
+        @fact solve_pf_runs(ap) => false
+        @fact solve_both_runs(ap) => false
     end
 end  # facts
 
@@ -242,8 +249,10 @@ facts("Testing career.jl") do
         end
     end
 
-    context("Test solve_vf runs") do
+    context("Test solve_(vf|pf|both) runs") do
         @fact solve_vf_runs(cp) => true
+        @fact solve_pf_runs(cp) => true
+        @fact solve_both_runs(cp) => true
     end
 end  # facts
 
@@ -266,8 +275,10 @@ facts("Testing ifp.jl") do
     @fact size(v_init) => shapes
     @fact size(c_init) => shapes
 
-    context("Test solve_vf runs") do
+    context("Test solve_(vf|pf|both) runs") do
         @fact solve_vf_runs(cp) => true
+        @fact solve_pf_runs(cp) => true
+        @fact solve_both_runs(cp) => true
     end
 end  # facts
 
@@ -296,8 +307,10 @@ facts("Testing jv.jl") do
     # solution to bellman is fixed point
     @fact v_star => roughly(bellman_operator(jv, v_star); atol=1e-6)
 
-    context("Test solve_vf runs") do
+    context("Test solve_(vf|pf|both) runs") do
         @fact solve_vf_runs(jv) => true
+        @fact solve_pf_runs(jv) => true
+        @fact solve_both_runs(jv) => true
     end
 end  # facts
 
@@ -336,8 +349,10 @@ facts("Testing lucastree.jl") do
         @fact prices => sort(prices)
     end
 
-    context("Test solve_vf doesn't run") do
+    context("Test solve_(vf|pf|both) doesn't run") do
         @fact solve_vf_runs(lt) => false
+        @fact solve_pf_runs(lt) => false
+        @fact solve_both_runs(lt) => false
     end
 end  # facts
 
@@ -389,8 +404,10 @@ facts("Testing odu.jl") do
     # phi_pfi fixed_point?
     @fact phi_pfi => roughly(res_wage_operator(sp, phi_pfi); atol=1e-5)
 
-    context("Test solve_vf runs") do
+    context("Test solve_(vf|pf|both) runs") do
         @fact solve_vf_runs(sp) => true
+        @fact solve_pf_runs(sp) => true
+        @fact solve_both_runs(sp) => true
     end
 end  # facts
 
@@ -428,8 +445,10 @@ facts("Testing optgrowth.jl") do
     @fact v_star[2:end] => roughly(bellman_operator(gm, v_star)[2:end];
                                    atol=5e-2)
 
-    context("Test solve_vf runs") do
+    context("Test solve_(vf|pf|both) runs") do
         @fact solve_vf_runs(gm) => true
+        @fact solve_pf_runs(gm) => true
+        @fact solve_both_runs(gm) => true
     end
 end  # facts
 

--- a/todo.TODO
+++ b/todo.TODO
@@ -13,71 +13,79 @@ Julia port:
    ☐ Matplotlib
    ☐ Pandas
    ☐ IPython Shell and Notebook
- ✔ Part 3: Introductory Applications @done (14-08-26 01:35)
-   ✔ Linear Algebra @done (14-07-10 00:47)
-   ✔ Finite Markov Chains
-   ✔ Shortest Paths
-   ✔ Schelling’s Segregation Model
-   ✔ LLN and CLT (for clt3d.py need to find gaussian_kde function in Julia) @done (14-08-11 14:10)
-      ✔ See kde from KernelDensity.jl @done (14-08-11 14:10)
-   ✔ Linear State Space Models @done (14-07-28 23:52)
-   ✔ A First Look at the Kalman Filter @done (14-07-29 01:46)
-   ✔ Infinite Horizon Dynamic Programming @done (14-06-30 13:09)
-   ✔ LQ Control Problems @done (14-07-01 23:27)
-   ✔ Rational Expectations Equilibrium @done (14-07-05 17:03)
-   ✔ The Lucas Asset Pricing Model @done (14-07-05 17:03)
       ☐ LucasTree code is really slow.
-   ✔ The Permanent Income Model @done (14-07-09 23:47)
- ✔ Part 4: Advanced Applications @done (14-08-26 01:35)
-   ✔ Continuous State Markov Chains @done (14-08-05 00:31)
       ☐ I could not to the reshaping and stop relying on broadcasting. Explicit for loops would be more efficient
-      ✔ Do boxplot example shown in exercise 3 @done (14-08-13 13:46)
-   ✔ Modeling Career Choice @done (14-08-05 02:13)
       ☐ The solutions notebook matches the python version, but I think we can do better. I think we can design more clever functions so that it is easy for people to call with different arguments
-   ✔ On-the-Job Search @done (14-08-14 10:43)
-   ✔ Search with Offer Distribution Unknown @done (14-08-25 09:07)
-      ✔ Fix bellman_operator in odu.jl. It is just cycling and not updating properly. @done (14-08-25 09:07)
-   ✔ Optimal Savings @done (14-08-25 09:07)
-   ✔ Robustness @done (14-08-25 09:07)
-   ✔ Linear Stochastic Models @done (14-08-25 09:07)
-   ✔ Estimation of Spectra @done (14-08-25 09:07)
-   ✔ Optimal Taxation @done (14-08-25 09:07)
 
 Julia (other):
 
  ☐ Add web references to top of files in examples/
  ☐ Create a macro that takes a function with just positional arguments and creates one with only kwargs
- ✔ I use my meshgrid function a few places. maybe I should just write it once. @done (14-08-26 01:34)
- ☐ Finish writing quad routines
- ✔ quad.jl @done (14-08-28 12:34)
-    ✔ qnwcheb @done (14-08-27 17:02)
-    ✔ qnwequi
-    ✔ qnwlege @done (14-08-27 17:02)
-    ✔ qnwnorm @done (14-08-27 17:33)
-    ✔ qnwlogn @done (14-08-27 20:33)
-    ✔ qnwsimp @done (14-08-27 20:36)
-    ✔ qnwtrap @done (14-08-27 20:36)
-    ✔ qnwunif @done (14-08-27 20:36)
-    ✔ quadrect @done (14-08-27 20:36)
-    ✔ qnwbeta @done (14-08-27 20:36)
-    ✔ qnwgamma @done (14-08-27 20:36)
+ ✔ Finish writing quad routines @done (14-12-03 16:36)
+
+Julia solve_vf:
+  ☐ lucastree has a non-standard structure. Too bad I won't have a solve_vf method for it...
+     ☐ Ditto for asset_pricing...
 
 Juila Tests:
    ☐ quadsum.jl
       ☐ Test m_quadratic_sum
-   ✔  asset_pricing.jl @done (14-08-27 10:19)
-   ✔  career.jl @done (14-08-27 10:19)
-   ✔  ifp.jl @done (14-08-27 10:19)
-   ✔  jv.jl @done (14-08-27 10:19)
-   ✔  lucastree.jl @done (14-08-27 10:19)
-   ✔  odu.jl @done (14-08-27 10:19)
-   ✔  optgrowth.jl @done (14-08-27 10:19)
-   ✔  mc_tools.jl @done (14-08-28 12:34)
-   ✔  quad.jl @done (14-08-28 12:34)
 
 Python:
    ☐ CompEcon
       ☐ Combine quadrature commits into single commit @maybe
       ☐ Unit tests for quadrature routines. Just use the demqua files, save the data, and match it in python.
       ☐ Root Finding:
-         ✔ Bisect @done (14-07-02 14:15)
+
+
+＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿
+Archive:
+ ✔ quad.jl @done (14-08-28 12:34) @project(Julia (other))
+ ✔  quad.jl @done (14-08-28 12:34) @project(Juila Tests)
+ ✔  mc_tools.jl @done (14-08-28 12:34) @project(Juila Tests)
+ ✔ quadrect @done (14-08-27 20:36) @project(Julia (other))
+ ✔ qnwunif @done (14-08-27 20:36) @project(Julia (other))
+ ✔ qnwtrap @done (14-08-27 20:36) @project(Julia (other))
+ ✔ qnwsimp @done (14-08-27 20:36) @project(Julia (other))
+ ✔ qnwgamma @done (14-08-27 20:36) @project(Julia (other))
+ ✔ qnwbeta @done (14-08-27 20:36) @project(Julia (other))
+ ✔ qnwlogn @done (14-08-27 20:33) @project(Julia (other))
+ ✔ qnwnorm @done (14-08-27 17:33) @project(Julia (other))
+ ✔ qnwlege @done (14-08-27 17:02) @project(Julia (other))
+ ✔ qnwcheb @done (14-08-27 17:02) @project(Julia (other))
+ ✔  optgrowth.jl @done (14-08-27 10:19) @project(Juila Tests)
+ ✔  odu.jl @done (14-08-27 10:19) @project(Juila Tests)
+ ✔  lucastree.jl @done (14-08-27 10:19) @project(Juila Tests)
+ ✔  jv.jl @done (14-08-27 10:19) @project(Juila Tests)
+ ✔  ifp.jl @done (14-08-27 10:19) @project(Juila Tests)
+ ✔  career.jl @done (14-08-27 10:19) @project(Juila Tests)
+ ✔  asset_pricing.jl @done (14-08-27 10:19) @project(Juila Tests)
+ ✔ Part 4: Advanced Applications @done (14-08-26 01:35) @project(Julia port)
+ ✔ Part 3: Introductory Applications @done (14-08-26 01:35) @project(Julia port)
+ ✔ I use my meshgrid function a few places. maybe I should just write it once. @done (14-08-26 01:34) @project(Julia (other))
+ ✔ Search with Offer Distribution Unknown @done (14-08-25 09:07) @project(Julia port)
+ ✔ Robustness @done (14-08-25 09:07) @project(Julia port)
+ ✔ Optimal Taxation @done (14-08-25 09:07) @project(Julia port)
+ ✔ Optimal Savings @done (14-08-25 09:07) @project(Julia port)
+ ✔ Linear Stochastic Models @done (14-08-25 09:07) @project(Julia port)
+ ✔ Fix bellman_operator in odu.jl. It is just cycling and not updating properly. @done (14-08-25 09:07) @project(Julia port)
+ ✔ Estimation of Spectra @done (14-08-25 09:07) @project(Julia port)
+ ✔ On-the-Job Search @done (14-08-14 10:43) @project(Julia port)
+ ✔ Do boxplot example shown in exercise 3 @done (14-08-13 13:46) @project(Julia port)
+ ✔ See kde from KernelDensity.jl @done (14-08-11 14:10) @project(Julia port)
+ ✔ LLN and CLT (for clt3d.py need to find gaussian_kde function in Julia) @done (14-08-11 14:10) @project(Julia port)
+ ✔ Modeling Career Choice @done (14-08-05 02:13) @project(Julia port)
+ ✔ Continuous State Markov Chains @done (14-08-05 00:31) @project(Julia port)
+ ✔ A First Look at the Kalman Filter @done (14-07-29 01:46) @project(Julia port)
+ ✔ Linear State Space Models @done (14-07-28 23:52) @project(Julia port)
+ ✔ Linear Algebra @done (14-07-10 00:47) @project(Julia port)
+ ✔ The Permanent Income Model @done (14-07-09 23:47) @project(Julia port)
+ ✔ The Lucas Asset Pricing Model @done (14-07-05 17:03) @project(Julia port)
+ ✔ Rational Expectations Equilibrium @done (14-07-05 17:03) @project(Julia port)
+ ✔ Bisect @done (14-07-02 14:15) @project(Python)
+ ✔ LQ Control Problems @done (14-07-01 23:27) @project(Julia port)
+ ✔ Infinite Horizon Dynamic Programming @done (14-06-30 13:09) @project(Julia port)
+ ✔ Finite Markov Chains @project(Julia port)
+ ✔ Shortest Paths @project(Julia port)
+ ✔ Schelling’s Segregation Model @project(Julia port)
+ ✔ qnwequi @project(Julia (other))


### PR DESCRIPTION
This PR adds an `AbstractModel` type that each of the types within the models subpackage now subtype.

In addition to the new type, we have new a few new functions:

* `init_values{T <: AbstractModel)(m::T)`: given a model object, this function returns the initial values used in the solutions notebook 
* `solve_vf(m::AbstractModel, [init=init_values(m); kwargs...])`: this function calls `init = init_values(m)` to construct a starting guess for the value function, then passes `f(x) = bellman_operator(m, x)` through `compute_fixed_point(f, init; kwargs...)` to compute the solution to the problem.
  * for models that don't implement `init_values` or `bellman_operator`  (`AssetPrices`, `LucasTree`), this function will send an error saying that `init_values` and/or `bellman_operator` is not defined for this model type
  * for the `ConsumerProblem` type in `ifp.jl` we write a special version of `solve_vf` that uses the more efficient `coleman_operator` instead of `bellman_operator`
* `solve_pf(m::AbstractModel, [init=init_values(m); kwargs...])`: This function gets the final value function from `vf = solve_vf(m, init; kwargs...)`, then computes and returns `get_greedy(m, vf)`
* `solve_both(m::AbstractModel, [init; kwargs...])`: This function uses the two previous functions to return both the final value function and policy function.

I have included tests for all of these methods (just that each of the functions does or doesn't run for a given model type).

If anyone has comments please let me know -- otherwise I'll merge this soon.

