### PR TITLE
Makes QuantEcon.jl importable

### DIFF
--- a/src/mc_tools.jl
+++ b/src/mc_tools.jl
@@ -137,7 +137,7 @@ end
 # output is a N x M matrix where each column is a stationary distribution
 # currently using lu decomposition to solve p(P-I)=0
 function mc_compute_stationary(mc::MarkovChain; method=:gth)
-    solvers = Dict([:gth => gth_solve, :lu => lu_solve, :eigen => eigen_solve])
+    solvers = Dict(:gth => gth_solve, :lu => lu_solve, :eigen => eigen_solve)
     solve = solvers[method]
 
     p,T = mc.p,eltype(mc.p)

--- a/src/models/jv.jl
+++ b/src/models/jv.jl
@@ -73,7 +73,7 @@ JvWorker(;A=1.4, alpha=0.6, bet=0.96, grid_size=50) = JvWorker(A, alpha, bet,
 #       depending on the value of ret_policies. This is probably not a
 #       huge deal, but it is something to be aware of
 function bellman_operator!(jv::JvWorker, V::Vector,
-                           out::Union(Vector, (Vector, Vector));
+                           out::Union(Vector, Tuple{Vector, Vector});
                            brute_force=true, ret_policies=false)
     # simplify notation
     G, pi_func, F, bet = jv.G, jv.pi_func, jv.F, jv.bet
@@ -169,7 +169,7 @@ function bellman_operator(jv::JvWorker, V::Vector; brute_force=true,
     return out
 end
 
-function get_greedy!(jv::JvWorker, V::Vector, out::(Vector, Vector);
+function get_greedy!(jv::JvWorker, V::Vector, out::Tuple{Vector, Vector};
                      brute_force=true)
     bellman_operator!(jv, V, out, ret_policies=true)
 end


### PR DESCRIPTION
Two fixes:

* Changed `Dict` syntax in mc_tools
* Changed `::(Vector, (Vector, Vector))` to `::(Vector, Tuple{Vector, Vector})`

