### PR TITLE
LQ Cross Product & Revamp

### DIFF
--- a/examples/lq_permanent_1.jl
+++ b/examples/lq_permanent_1.jl
@@ -20,7 +20,7 @@ B = [-1.0, 0.0]
 C = [sigma, 0.0]
 
 # == Compute solutions and simulate == #
-lq = LQ(Q, R, A, B, C, bet, T, Rf)
+lq = LQ(Q, R, A, B, C; bet=bet, capT=T, rf=Rf)
 x0 = [0.0, 1.0]
 xp, up, wp = compute_sequence(lq, x0)
 

--- a/src/lqcontrol.jl
+++ b/src/lqcontrol.jl
@@ -149,7 +149,7 @@ function _compute_sequence{T}(lq::LQ, x0::Vector{T}, policies)
 	
 	x_path[:,1] = x0
 	u_path[:,1] = -(first(policies)*x0)
-	w_path      =  [dot(lq.C,randn(j)) for i=1:(term+1)]
+	w_path      = [dot(lq.C,randn(j)) for i=1:(term+1)]
 
     for t = 2:term
         f = policies[t]

--- a/src/lqcontrol.jl
+++ b/src/lqcontrol.jl
@@ -24,9 +24,6 @@ type LQ
     bet::Real
     term::Union(Int, Nothing) # terminal period
     Rf::ScalarOrArray
-    k::Int
-    n::Int
-    j::Int
     P::ScalarOrArray
     d::Real
     F::ScalarOrArray # policy rule
@@ -62,7 +59,7 @@ function LQ(Q::ScalarOrArray,
     P = copy(Rf)
     d = 0.0
 
-    LQ(Q, R, A, B, C, bet, term, Rf, k, n, j, P, d, F)
+    LQ(Q, R, A, B, C, bet, term, Rf, P, d, F)
 end
 
 # make kwarg version

--- a/src/lqcontrol.jl
+++ b/src/lqcontrol.jl
@@ -129,7 +129,7 @@ function _compute_sequence{T}(lq::LQ, x0::T, policies)
 	
 	x_path[1] = x0
 	u_path[1] = -(first(policies)*x0)
-	w_path    = lq.C .* randn(term+1)
+	w_path    = lq.C * randn(term+1)
 
     for t = 2:term
         f = policies[t]
@@ -143,13 +143,13 @@ end
 
 # dispatch for a vector problem
 function _compute_sequence{T}(lq::LQ, x0::Vector{T}, policies)
-	n, term = length(x0), length(policies)
+	n, j, term = length(x0), length(lq.C), length(policies)
 	x_path = Array(T, n, term+1)
 	u_path = Array(T, n, term)
 	
 	x_path[:,1] = x0
 	u_path[:,1] = -(first(policies)*x0)
-	w_path    = lq.C .* randn(term+1)
+	w_path      =  [dot(lq.C,randn(j)) for i=1:(term+1)]
 
     for t = 2:term
         f = policies[t]

--- a/src/lqcontrol.jl
+++ b/src/lqcontrol.jl
@@ -164,10 +164,9 @@ function compute_sequence(lq::LQ, x0::ScalarOrArray, ts_length=100)
     Ax, Bu = A*x_path[term], B*u_path[term]
     x_path[end] = Ax + Bu + w_path[end]
 
-    # This is very ugly
-    if T == Number
-		return x_path, u_path, w_path
-	else
-		return hcat(x_path...), hcat(u_path...), hcat(w_path...)
-	end
+    # This is very ugly, ideally should dispatch on Number versus Array
+    # would improve performance as well
+    isa(T,Number) && return x_path, u_path, w_path
+	
+	return hcat(x_path...), hcat(u_path...), hcat(w_path...)
 end

--- a/src/lqcontrol.jl
+++ b/src/lqcontrol.jl
@@ -170,7 +170,7 @@ function compute_sequence(lq::LQ, x0::ScalarOrArray, ts_length=100)
     term = min(ts_length, lq.term)
 
     # Compute and record the sequence of policies
-    if isa(lq.term,nothing)
+    if isa(lq.term,Nothing)
         stationary_values!(lq)
         policies = fill(lq.F,term)
     else

--- a/src/lqcontrol.jl
+++ b/src/lqcontrol.jl
@@ -23,7 +23,7 @@ type LQ
     C::ScalarOrArray
     N::ScalarOrArray
     bet::Real
-    capT::Union(Int, Nothing) # capTinal period
+    capT::Union(Int, Nothing) # terminal period
     rf::ScalarOrArray
     P::ScalarOrArray
     d::Real
@@ -39,7 +39,7 @@ function LQ(Q::ScalarOrArray,
 			bet::ScalarOrArray        = 1.0,
 			capT::Union(Int, Nothing) = nothing,
 			rf::ScalarOrArray         = fill(NaN, size(R)...))
-    
+
     k = size(Q, 1)
     n = size(R, 1)
     F = k==n==1 ? zero(Float64) : zeros(Float64, k, n)
@@ -48,6 +48,7 @@ function LQ(Q::ScalarOrArray,
 
     LQ(Q, R, A, B, C, N, bet, capT, rf, P, d, F)
 end
+
 
 # make kwarg version
 function LQ(Q::ScalarOrArray,
@@ -160,7 +161,7 @@ function _compute_sequence{T}(lq::LQ, x0::Vector{T}, policies)
     for t = 2:capT
         f = policies[t]
         x_path[:,t] = lq.A*x_path[:,t-1] + lq.B*u_path[:,t-1] + w_path[t]
-        u_path[:,t] = -(f*x_path[t])
+        u_path[:,t] = -(f*x_path[:,t])
     end
     x_path[:,end] = lq.A*x_path[:,capT] + lq.B*u_path[:,capT] + w_path[end]
 

--- a/src/lqcontrol.jl
+++ b/src/lqcontrol.jl
@@ -34,7 +34,7 @@ function LQ(Q::ScalarOrArray,
             R::ScalarOrArray,
             A::ScalarOrArray,
             B::ScalarOrArray,
-			C::ScalarOrArray          = zeros(size(R,1)),
+			C::ScalarOrArray          = zeros(size(R, 1)),
 			N::ScalarOrArray          = zero(B'A),
 			bet::ScalarOrArray        = 1.0,
 			capT::Union(Int, Nothing) = nothing,
@@ -55,7 +55,7 @@ function LQ(Q::ScalarOrArray,
 			R::ScalarOrArray,
 			A::ScalarOrArray,
 			B::ScalarOrArray,
-			C::ScalarOrArray          = zeros(size(R,1)),
+			C::ScalarOrArray          = zeros(size(R, 1)),
 			N::ScalarOrArray          = zero(B'A);
 			bet::ScalarOrArray        = 1.0,
 			capT::Union(Int, Nothing) = nothing,
@@ -107,16 +107,15 @@ function stationary_values!(lq::LQ)
 end
 
 function stationary_values(lq::LQ)
-	_lq = LQ(
-			copy(lq.Q), 
-			copy(lq.R), 
-			copy(lq.A), 
-			copy(lq.B), 
-			copy(lq.C), 
-			copy(lq.N),
-			copy(lq.bet), 
-			lq.capT,
-			copy(lq.rf))
+	_lq = LQ(copy(lq.Q),
+			 copy(lq.R),
+			 copy(lq.A),
+			 copy(lq.B),
+			 copy(lq.C),
+			 copy(lq.N),
+			 copy(lq.bet),
+			 lq.capT,
+			 copy(lq.rf))
 
     stationary_values!(_lq)
     return _lq.P, _lq.F, _lq.d
@@ -128,7 +127,7 @@ function _compute_sequence{T}(lq::LQ, x0::T, policies)
 
 	x_path = Array(T, capT+1)
 	u_path = Array(T, capT)
-	
+
 	x_path[1] = x0
 	u_path[1] = -(first(policies)*x0)
 	w_path    = lq.C * randn(capT+1)
@@ -146,24 +145,24 @@ end
 # Dispatch for a vector problem
 function _compute_sequence{T}(lq::LQ, x0::Vector{T}, policies)
     # Ensure correct dimensionality
-    n, j, k = size(lq.C,1), size(lq.C,2), size(lq.B,1)
+    n, j, k = size(lq.C, 1), size(lq.C, 2), size(lq.B, 2)
     capT = length(policies)
 
-    A, B, C = lq.A, reshape(lq.B,n,k), reshape(lq.C,n,j) 
-	
+    A, B, C = lq.A, reshape(lq.B, n, k), reshape(lq.C, n, j)
+
     x_path = Array(T, n, capT+1)
-    u_path = Array(T, n, capT)
+    u_path = Array(T, k, capT)
     w_path = [vec(C*randn(j)) for i=1:(capT+1)]
-	
-	x_path[:,1] = x0
-	u_path[:,1] = -(first(policies)*x0)
+
+	x_path[:, 1] = x0
+	u_path[:, 1] = -(first(policies)*x0)
 
     for t = 2:capT
         f = policies[t]
-        x_path[:,t] = A*x_path[:,t-1] + B*u_path[:,t-1] + w_path[t]
-        u_path[:,t] = -(f*x_path[:,t])
+        x_path[:, t] = A*x_path[: ,t-1] + B*u_path[:, t-1] + w_path[t]
+        u_path[:, t] = -(f*x_path[:, t])
     end
-    x_path[:,end] = A*x_path[:,capT] + B*u_path[:,capT] + w_path[end]
+    x_path[:, end] = A*x_path[:, capT] + B*u_path[:, capT] + w_path[end]
 
     x_path, u_path, w_path
 end
@@ -172,9 +171,9 @@ function compute_sequence(lq::LQ, x0::ScalarOrArray, ts_length=100)
     capT = min(ts_length, lq.capT)
 
     # Compute and record the sequence of policies
-    if isa(lq.capT,Nothing)
+    if isa(lq.capT, Nothing)
         stationary_values!(lq)
-        policies = fill(lq.F,capT)
+        policies = fill(lq.F, capT)
     else
         policies = Array(typeof(lq.F), capT)
         for t = 1:capT

--- a/src/lqcontrol.jl
+++ b/src/lqcontrol.jl
@@ -170,7 +170,7 @@ function compute_sequence(lq::LQ, x0::ScalarOrArray, ts_length=100)
     term = min(ts_length, lq.term)
 
     # Compute and record the sequence of policies
-    if lq.term == nothing
+    if isa(lq.term,nothing)
         stationary_values!(lq)
         policies = fill(lq.F,term)
     else
@@ -180,5 +180,6 @@ function compute_sequence(lq::LQ, x0::ScalarOrArray, ts_length=100)
             policies[t] = lq.F
         end
     end
+
 	_compute_sequence(lq, x0, policies)
 end

--- a/src/lqcontrol.jl
+++ b/src/lqcontrol.jl
@@ -144,13 +144,14 @@ end
 
 # Dispatch for a vector problem
 function _compute_sequence{T}(lq::LQ, x0::Vector{T}, policies)
-    n, j = size(lq.C,1), size(lq.C,2)
+    n, j, k = size(lq.C,1), size(lq.C,2), size(lq.B,1)
 	term = length(policies)
 
     x_path = Array(T, n, term+1)
     u_path = Array(T, n, term)
 
-    C = reshape(lq.C,n,j) # Ensure correct dimensionality for w_path
+    # Ensure correct dimensionality
+    B, C = reshape(lq.B,n,k), reshape(lq.C,n,j) 
     w_path = [vec(C*randn(j)) for i=1:(term+1)]
 	
 	x_path[:,1] = x0
@@ -158,7 +159,7 @@ function _compute_sequence{T}(lq::LQ, x0::Vector{T}, policies)
 
     for t = 2:term
         f = policies[t]
-        x_path[:,t] = lq.A*x_path[t-1] + lq.B*u_path[t-1] + w_path[t]
+        x_path[:,t] = lq.A*x_path[:,t-1] + lq.B*u_path[:,t-1] + w_path[t]
         u_path[:,t] = -(f*x_path[t])
     end
     x_path[:,end] = lq.A*x_path[:,term] + lq.B*u_path[:,term] + w_path[end]

--- a/src/lqcontrol.jl
+++ b/src/lqcontrol.jl
@@ -34,11 +34,11 @@ function LQ(Q::ScalarOrArray,
             R::ScalarOrArray,
             A::ScalarOrArray,
             B::ScalarOrArray,
-			C::ScalarOrArray          = zeros(size(R, 1)),
-			N::ScalarOrArray          = zero(B'A),
-			bet::ScalarOrArray        = 1.0,
-			capT::Union(Int, Nothing) = nothing,
-			rf::ScalarOrArray         = fill(NaN, size(R)...))
+            C::ScalarOrArray          = zeros(size(R, 1)),
+            N::ScalarOrArray          = zero(B'A),
+            bet::ScalarOrArray        = 1.0,
+            capT::Union(Int, Nothing) = nothing,
+            rf::ScalarOrArray         = fill(NaN, size(R)...))
 
     k = size(Q, 1)
     n = size(R, 1)
@@ -52,15 +52,15 @@ end
 
 # make kwarg version
 function LQ(Q::ScalarOrArray,
-			R::ScalarOrArray,
-			A::ScalarOrArray,
-			B::ScalarOrArray,
-			C::ScalarOrArray          = zeros(size(R, 1)),
-			N::ScalarOrArray          = zero(B'A);
-			bet::ScalarOrArray        = 1.0,
-			capT::Union(Int, Nothing) = nothing,
-			rf::ScalarOrArray         = fill(NaN, size(R)...))
-	LQ(Q, R, A, B, C, N, bet, capT, rf)
+            R::ScalarOrArray,
+            A::ScalarOrArray,
+            B::ScalarOrArray,
+            C::ScalarOrArray          = zeros(size(R, 1)),
+            N::ScalarOrArray          = zero(B'A);
+            bet::ScalarOrArray        = 1.0,
+            capT::Union(Int, Nothing) = nothing,
+            rf::ScalarOrArray         = fill(NaN, size(R)...))
+    LQ(Q, R, A, B, C, N, bet, capT, rf)
 end
 
 function update_values!(lq::LQ)
@@ -107,15 +107,15 @@ function stationary_values!(lq::LQ)
 end
 
 function stationary_values(lq::LQ)
-	_lq = LQ(copy(lq.Q),
-			 copy(lq.R),
-			 copy(lq.A),
-			 copy(lq.B),
-			 copy(lq.C),
-			 copy(lq.N),
-			 copy(lq.bet),
-			 lq.capT,
-			 copy(lq.rf))
+    _lq = LQ(copy(lq.Q),
+             copy(lq.R),
+             copy(lq.A),
+             copy(lq.B),
+             copy(lq.C),
+             copy(lq.N),
+             copy(lq.bet),
+             lq.capT,
+             copy(lq.rf))
 
     stationary_values!(_lq)
     return _lq.P, _lq.F, _lq.d
@@ -123,14 +123,14 @@ end
 
 # Dispatch for a scalar problem
 function _compute_sequence{T}(lq::LQ, x0::T, policies)
-	capT = length(policies)
+    capT = length(policies)
 
-	x_path = Array(T, capT+1)
-	u_path = Array(T, capT)
+    x_path = Array(T, capT+1)
+    u_path = Array(T, capT)
 
-	x_path[1] = x0
-	u_path[1] = -(first(policies)*x0)
-	w_path    = lq.C * randn(capT+1)
+    x_path[1] = x0
+    u_path[1] = -(first(policies)*x0)
+    w_path    = lq.C * randn(capT+1)
 
     for t = 2:capT
         f = policies[t]
@@ -154,8 +154,8 @@ function _compute_sequence{T}(lq::LQ, x0::Vector{T}, policies)
     u_path = Array(T, k, capT)
     w_path = [vec(C*randn(j)) for i=1:(capT+1)]
 
-	x_path[:, 1] = x0
-	u_path[:, 1] = -(first(policies)*x0)
+    x_path[:, 1] = x0
+    u_path[:, 1] = -(first(policies)*x0)
 
     for t = 2:capT
         f = policies[t]
@@ -182,5 +182,5 @@ function compute_sequence(lq::LQ, x0::ScalarOrArray, ts_length=100)
         end
     end
 
-	_compute_sequence(lq, x0, policies)
+    _compute_sequence(lq, x0, policies)
 end

--- a/src/lqcontrol.jl
+++ b/src/lqcontrol.jl
@@ -145,14 +145,14 @@ end
 
 # Dispatch for a vector problem
 function _compute_sequence{T}(lq::LQ, x0::Vector{T}, policies)
+    # Ensure correct dimensionality
     n, j, k = size(lq.C,1), size(lq.C,2), size(lq.B,1)
-	capT = length(policies)
+    capT = length(policies)
 
+    A, B, C = lq.A, reshape(lq.B,n,k), reshape(lq.C,n,j) 
+	
     x_path = Array(T, n, capT+1)
     u_path = Array(T, n, capT)
-
-    # Ensure correct dimensionality
-    B, C = reshape(lq.B,n,k), reshape(lq.C,n,j) 
     w_path = [vec(C*randn(j)) for i=1:(capT+1)]
 	
 	x_path[:,1] = x0
@@ -160,10 +160,10 @@ function _compute_sequence{T}(lq::LQ, x0::Vector{T}, policies)
 
     for t = 2:capT
         f = policies[t]
-        x_path[:,t] = lq.A*x_path[:,t-1] + lq.B*u_path[:,t-1] + w_path[t]
+        x_path[:,t] = A*x_path[:,t-1] + B*u_path[:,t-1] + w_path[t]
         u_path[:,t] = -(f*x_path[:,t])
     end
-    x_path[:,end] = lq.A*x_path[:,capT] + lq.B*u_path[:,capT] + w_path[end]
+    x_path[:,end] = A*x_path[:,capT] + B*u_path[:,capT] + w_path[end]
 
     x_path, u_path, w_path
 end

--- a/test/test_lqcontrol.jl
+++ b/test/test_lqcontrol.jl
@@ -33,18 +33,18 @@ facts("Testing lqcontrol.jl") do
         # solve by hand
         u_0 = (-2.*lq_scalar.A*lq_scalar.B*lq_scalar.bet*lq_scalar.rf) /
            (2.*lq_scalar.Q+lq_scalar.bet*lq_scalar.rf*2lq_scalar.B^2)*x0
-        x_1 = lq_scalar.A * x0 + lq_scalar.B * u_0 + w_seq[1, end]
+        x_1 = lq_scalar.A * x0 + lq_scalar.B * u_0 + w_seq[end]
 
         @fact u_0[1] => roughly(u_seq[end]; rough_kwargs...)
         @fact x_1[1] => roughly(x_seq[end]; rough_kwargs...)
     end
 
     context("test matrix solutions") do
-        x0 = randn(2) .* 25
+        x0 = randn(2) * 25
         x_seq, u_seq, w_seq = compute_sequence(lq_mat, x0)
 
         @fact sum(u_seq) => roughly(0.95 * sum(x0); rough_kwargs...)
-        @fact x_seq[:, end] => roughly(zeros(x0); rough_kwargs...)
+        @fact x_seq[:,end] => roughly(zeros(x0); rough_kwargs...)
     end
 
     context("test stationary matrix") do

--- a/test/test_lqcontrol.jl
+++ b/test/test_lqcontrol.jl
@@ -62,5 +62,31 @@ facts("Testing lqcontrol.jl") do
         @fact p_answer => roughly(P; rough_kwargs...)
     end
 
+    context("test runs a (n,k,j) = (2,1,1) model") do
+        # == Model parameters == #
+        r = 0.05
+        bet = 1 / (1 + r)
+        T = 45
+        c_bar = 2.0
+        sigma = 0.25
+        mu = 1.0
+        q = 1e6
+
+        # == Formulate as an LQ problem == #
+        Q = 1.0
+        R = zeros(2, 2)
+        Rf = zeros(2, 2); Rf[1, 1] = q
+        A = [1.0+r -c_bar+mu;
+             0.0 1.0]
+        B = [-1.0, 0.0]
+        C = [sigma, 0.0]
+
+        # == Compute solutions and simulate == #
+        lq = LQ(Q, R, A, B, C; bet=bet, capT=T, rf=Rf)
+        x0 = [0.0, 1.0]
+        xp, up, wp = compute_sequence(lq, x0)
+        @fact true => true  # just assert true if we made it to this point
+    end
+
 end  # facts
 end  # module

--- a/test/test_lqcontrol.jl
+++ b/test/test_lqcontrol.jl
@@ -16,15 +16,15 @@ b    = -1.
 c    = .05
 β    = .95
 n    = 0.
-term = 1
-lq_scalar = LQ(q, r, a, b, c, n, β, term, rf)
+capT = 1
+lq_scalar = LQ(q, r, a, b, c, n, β, capT, rf)
 
 Q  = [0. 0.; 0. 1]
 R  = [1. 0.; 0. 0]
 rf = eye(2) .* 100
 A  = fill(0.95, 2, 2)
 B  = fill(-1.0, 2, 2)
-lq_mat = LQ(Q, R, A, B, bet=β, term=term, rf=rf)
+lq_mat = LQ(Q, R, A, B, bet=β, capT=capT, rf=rf)
 
 facts("Testing lqcontrol.jl") do
     context("Test scalar sequences with exact by hand solution") do

--- a/test/test_lqcontrol.jl
+++ b/test/test_lqcontrol.jl
@@ -8,42 +8,35 @@ using Compat
 rough_kwargs = @compat Dict(:atol => 1e-13, :rtol => 1e-4)
 
 # set up
-q = 1.
-r = 1.
-rf = 1.
-a = .95
-b = -1.
-c = .05
-β = .95
-T = 1
-lq_scalar = LQ(q, r, a, b, c, β, T, rf)
+q    = 1.
+r    = 1.
+rf   = 1.
+a    = .95
+b    = -1.
+c    = .05
+β    = .95
+n    = 0.
+term = 1
+lq_scalar = LQ(q, r, a, b, c, n, β, term, rf)
 
-Q = [0. 0.; 0. 1]
-R = [1. 0.; 0. 0]
-RF = eye(2) .* 100
-A = fill(0.95, 2, 2)
-B = fill(-1.0, 2, 2)
-lq_mat = LQ(Q, R, A, B, bet=β, T=T, Rf=RF)
-
+Q  = [0. 0.; 0. 1]
+R  = [1. 0.; 0. 0]
+rf = eye(2) .* 100
+A  = fill(0.95, 2, 2)
+B  = fill(-1.0, 2, 2)
+lq_mat = LQ(Q, R, A, B, bet=β, term=term, rf=rf)
 
 facts("Testing lqcontrol.jl") do
-    # Make sure to test values come out of the constructor properly
-    context("test constructor convert fields to matrix") do
-        for f in [:Q, :R, :B, :B], l in [lq_scalar, lq_mat]
-            @fact typeof(getfield(l, f)) <: Matrix => true
-        end
-    end
-
     context("Test scalar sequences with exact by hand solution") do
         x0 = 2.0
         x_seq, u_seq, w_seq = compute_sequence(lq_scalar, x0)
         # solve by hand
-        u_0 = (-2.*lq_scalar.A.*lq_scalar.B.*lq_scalar.bet.*lq_scalar.Rf) /
-           (2.*lq_scalar.Q+lq_scalar.bet.*lq_scalar.Rf.*2lq_scalar.B.^2).*x0
+        u_0 = (-2.*lq_scalar.A*lq_scalar.B*lq_scalar.bet*lq_scalar.rf) /
+           (2.*lq_scalar.Q+lq_scalar.bet*lq_scalar.rf*2lq_scalar.B^2)*x0
         x_1 = lq_scalar.A * x0 + lq_scalar.B * u_0 + w_seq[1, end]
 
-        @fact u_0[1] => roughly(u_seq[1, end]; rough_kwargs...)
-        @fact x_1[1] => roughly(x_seq[1, end]; rough_kwargs...)
+        @fact u_0[1] => roughly(u_seq[end]; rough_kwargs...)
+        @fact x_1[1] => roughly(x_seq[end]; rough_kwargs...)
     end
 
     context("test matrix solutions") do


### PR DESCRIPTION
This PR adds support for a cross product term in the LQ dynamic programming problem, addressing #16.

Additionally:
* Cleaned up the linear algebra so that algorithms work natively with arrays and scalars without having to convert everything to `Array(T,1,1)` and use broadcast operators everywhere.
* Now `compute_sequence` returns a one dimensional array for scalar problems, and a two dimensional array for vector problems. 

Things to discuss:
* I have renamed the variable for the terminal period (in the finite horizon case) `T` to `term` since `T` is a very special name in the Julia universe, and nearly always used for a type variable. Is this okay?
* I renamed `Rf` to `rf` to cut down on the capital variables floating around, happy to revert this if it offends.

Things not in this PR:
* Should we rename `LQ` to `LinearQuadratic` or `LinearQuadraticControl` in keeping with the julian camel case naming convention for types?
* I have not implemented `Nullable` types for the optional arguments.... I had a quick go at this, but ran out of time. It took me a whole day to get this thing to work and there are other issues that need attending to, but I think the code is a lot cleaner now than before.

N.b. Travis is failing because of some stuff in `robustlq.jl`. If [this line](https://github.com/QuantEcon/QuantEcon.jl/blob/master/src/QuantEcon.jl#L122) is commented out from `QuantEcon.jl` everything behaves itself.