### PR TITLE
Update mc_convergence_plot.jl

### DIFF
--- a/examples/mc_convergence_plot.jl
+++ b/examples/mc_convergence_plot.jl
@@ -30,5 +30,6 @@ end
 
 ax[:scatter](x_vals, y_vals, z_vals, c="r", s = 60)
 
+P = MarkovChain(P)
 psi_star = mc_compute_stationary(P)
 ax[:scatter](psi_star[1], psi_star[2], psi_star[3], c="k", s = 60)


### PR DESCRIPTION
P needs to be of the type MarkovChain to go into mc_compute stationary. You mentioned you thought about adding the old method back right? But the MarkovChain constructor would be useful in checking whether the array satisfies the condition sum(P[i,:]) = 1. Or do you want to integrate that into every MarkovChain routine?