### PR TITLE
New features for mc_tools

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -8,6 +8,6 @@ MAT
 FactCheck
 DataStructures
 Compat
-Graphs
+LightGraphs
 IterationManagers
 Docile

--- a/src/QuantEcon.jl
+++ b/src/QuantEcon.jl
@@ -3,7 +3,7 @@ module QuantEcon
 import Base: mean, std, var, show, isapprox
 
 # 3rd party
-using Distributions, Graphs
+using Distributions
 import Distributions: pdf, skewness
 using DSP: TFFilter, freqz
 using Compat
@@ -43,6 +43,7 @@ export
 # mc_tools
     MarkovChain,
     mc_compute_stationary, mc_sample_path, mc_sample_path!,
+    period, is_irreducible, is_aperiodic, recurrent_classes, communication_classes, simulate,
 
 # gth_solve
     gth_solve,


### PR DESCRIPTION
* Moved to LightGraphs for graph calculations
* New functions added

`recurrent_classes(mc::MarkovChain)`
`communication_classes(mc::MarkovChain)`
`is_irreducible(mc::MarkovChain)`
`period(mc::MarkovChain)`

Tests for these new functions are not included in this pull. I'm going to change up the tests file, so I'm submitting this pull and making those modifications separately, but all the old tests pass fine with the new code.