### PR TITLE
BUG: Fix a bug in mc_tools

### DIFF
--- a/src/mc_tools.jl
+++ b/src/mc_tools.jl
@@ -229,7 +229,7 @@ function mc_sample_path(mc::MarkovChain,
                         init::Int=rand(1:n_states(mc)),
                         sample_size::Int=1000;
                         burn::Int=0)
-    samples = Array(Int, sample_size) # +1 extra for the init
+    samples = Array(Int, sample_size)
     samples[1] = init
     mc_sample_path!(mc, samples)
     samples[burn+1:end]

--- a/src/mc_tools.jl
+++ b/src/mc_tools.jl
@@ -96,6 +96,9 @@ function gth_solve{T<:Real}(original::Matrix{T})
     @inbounds for k in 1:n-1
         scale = sum(a[k, k+1:n])
         if scale <= zero(T)
+            # There is one (and only one) recurrent class contained in
+            # {1, ..., k};
+            # compute the solution associated with that recurrent class.
             n = k
             break
         end
@@ -107,7 +110,7 @@ function gth_solve{T<:Real}(original::Matrix{T})
     end
 
     # backsubstitution
-    x[end] = 1
+    x[n] = 1
     @inbounds for k in n-1:-1:1, i in k+1:n
         x[k] += x[i] * a[i, k]
     end

--- a/test/test_mc_tools.jl
+++ b/test/test_mc_tools.jl
@@ -27,6 +27,11 @@ mc6_stationary = [3//7, 4//7]
 mc7 = [1 0; 0 1]
 mc7_stationary = [1 0;0 1]
 
+# Reducible mc with a unique recurrent class,
+# where n=2 is a transient state
+mc10 = [1. 0; 1. 0]
+mc10_stationary = [1., 0]
+
 mc1 = MarkovChain(mc1)
 mc2 = MarkovChain(mc2)
 mc3 = MarkovChain(mc3)
@@ -34,6 +39,7 @@ mc4 = MarkovChain(mc4)
 mc5 = MarkovChain(mc5)
 mc6 = MarkovChain(mc6)
 mc7 = MarkovChain(mc7)
+mc10 = MarkovChain(mc10)
 
 # examples from
 # Graph-Theoretic Analysis of Finite Markov Chains by J.P. Jarvis & D. R. Shier
@@ -92,6 +98,7 @@ facts("Testing mc_tools.jl") do
         @fact mc_compute_stationary(mc5) --> mc5_stationary
         @fact mc_compute_stationary(mc6) --> mc6_stationary
         @fact mc_compute_stationary(mc7) --> mc7_stationary
+        @fact mc_compute_stationary(mc10) --> mc10_stationary
     end
 
     context("test gth_solve with KMR matrices") do


### PR DESCRIPTION
[This bug](https://github.com/QuantEcon/QuantEcon.jl/commit/5a96644f1a19fd5aa35c18ebac92d184fe5df3f5) has been left untouched.

With the current code, we have:

```julia
julia> mc = MarkovChain([1. 0; 1. 0])
Discrete Markov Chain
stochastic matrix:
2x2 Array{Float64,2}:
 1.0  0.0
 1.0  0.0


julia> mc_compute_stationary(mc)
2-element Array{Float64,1}:
 0.0
 1.0

```

This PR

* changes `x[end]` back to `x[n]`; and
* adds the above instance to the tests.
