### PR TITLE
Random MarkovChain

### DIFF
--- a/src/QuantEcon.jl
+++ b/src/QuantEcon.jl
@@ -104,7 +104,10 @@ export
 
 # quadsums
     var_quadratic_sum,
-    m_quadratic_sum
+    m_quadratic_sum,
+
+# random_mc
+    random_markov_chain, random_stochastic_matrix
 
 include("util.jl")
 ##### includes
@@ -125,6 +128,7 @@ include("matrix_eqn.jl")
 include("robustlq.jl")
 include("quad.jl")
 include("quadsums.jl")
+include("random_mc.jl")
 
 # include the models file/module
 include("Models.jl")

--- a/src/random_mc.jl
+++ b/src/random_mc.jl
@@ -1,0 +1,134 @@
+#=
+Generate a MarkovChain randomly.
+
+@author : Daisuke Oyama
+
+=#
+import StatsBase: sample
+import QuantEcon: MarkovChain
+
+
+"""
+Return a randomly sampled MarkovChain instance with n states.
+
+##### Arguments
+
+- `n::Integer` : Number of states.
+
+##### Returns
+
+- `mc::MarkovChain` : MarkovChain instance.
+
+"""
+function random_markov_chain(n::Integer)
+    p = random_stochastic_matrix(n)
+    mc = MarkovChain(p)
+    return mc
+end
+
+
+"""
+Return a randomly sampled MarkovChain instance with n states, where each state
+has k states with positive transition probability.
+
+##### Arguments
+
+- `n::Integer` : Number of states.
+
+##### Returns
+
+- `mc::MarkovChain` : MarkovChain instance.
+
+"""
+function random_markov_chain(n::Integer, k::Integer)
+    p = random_stochastic_matrix(n, k)
+    mc = MarkovChain(p)
+    return mc
+end
+
+
+"""
+Return a randomly sampled n x n stochastic matrix.
+
+##### Arguments
+
+- `n::Integer` : Number of states.
+- `k::Integer` : Number of nonzero entries in each row of the matrix.
+
+##### Returns
+
+- `p::Array` : Stochastic matrix.
+
+"""
+function random_stochastic_matrix(n::Integer)
+    if n <= 0
+        throw(ArgumentError("n must be a positive integer"))
+    end
+
+    p = random_probvec(n, n)
+
+    return transpose(p)
+end
+
+
+"""
+Return a randomly sampled n x n stochastic matrix with k nonzero entries for
+each row.
+
+##### Arguments
+
+- `n::Integer` : Number of states.
+- `k::Integer` : Number of nonzero entries in each row of the matrix.
+
+##### Returns
+
+- `p::Array` : Stochastic matrix.
+
+"""
+function random_stochastic_matrix(n::Integer, k::Integer)
+    if !(n > 0)
+        throw(ArgumentError("n must be a positive integer"))
+    end
+    if !(k > 0 && k <= n)
+        throw(ArgumentError("k must be an integer with 0 < k <= n"))
+    end
+
+    # Randomly sample row indices for each column for nonzero values
+    row_indices = @compat Vector{Int}(k*n)
+    for j in 1:n
+        row_indices[(j-1)*k+1:j*k] = sample(1:n, k, replace=false)
+    end
+
+    probvecs = random_probvec(k, n)
+
+    p = zeros(n, n)
+    for j in 1:n
+        for i in 1:k
+            p[row_indices[(j-1)*k+i], j] = probvecs[i, j]
+        end
+    end
+
+    return transpose(p)
+end
+
+
+"""
+Return m randomly sampled probability vectors of size k.
+
+##### Arguments
+
+- `k::Integer` : Number of probability vectors.
+- `m::Integer` : Size of each probability vectors.
+
+##### Returns
+
+- `a::Array` : Array of shape (k, m) containing probability vectors as colums.
+
+"""
+function random_probvec(k::Integer, m::Integer)
+    x = Array(Float64, (k+1, m))
+
+    r = rand((k-1, m))
+    x[1, :], x[2:end-1, :], x[end, :] = 0, sort(r, 1), 1
+    return diff(x, 1)
+end

--- a/src/random_mc.jl
+++ b/src/random_mc.jl
@@ -8,6 +8,8 @@ import StatsBase: sample
 import QuantEcon: MarkovChain
 
 
+# random_markov_chain
+
 """
 Return a randomly sampled MarkovChain instance with n states.
 
@@ -46,6 +48,8 @@ function random_markov_chain(n::Integer, k::Integer)
     return mc
 end
 
+
+# random_stochastic_matrix
 
 """
 Return a randomly sampled n x n stochastic matrix.
@@ -93,13 +97,16 @@ function random_stochastic_matrix(n::Integer, k::Integer)
         throw(ArgumentError("k must be an integer with 0 < k <= n"))
     end
 
+    k == n && return random_stochastic_matrix(n)
+
+    # if k < n
+    probvecs = random_probvec(k, n)
+
     # Randomly sample row indices for each column for nonzero values
     row_indices = @compat Vector{Int}(k*n)
     for j in 1:n
         row_indices[(j-1)*k+1:j*k] = sample(1:n, k, replace=false)
     end
-
-    probvecs = random_probvec(k, n)
 
     p = zeros(n, n)
     for j in 1:n
@@ -112,6 +119,8 @@ function random_stochastic_matrix(n::Integer, k::Integer)
 end
 
 
+# random_probvec
+
 """
 Return m randomly sampled probability vectors of size k.
 
@@ -119,16 +128,23 @@ Return m randomly sampled probability vectors of size k.
 
 - `k::Integer` : Number of probability vectors.
 - `m::Integer` : Size of each probability vectors.
+- `rng::AbstractRNG` : (Optional) Random number generator
 
 ##### Returns
 
 - `a::Array` : Array of shape (k, m) containing probability vectors as colums.
 
 """
-function random_probvec(k::Integer, m::Integer)
+function random_probvec(k::Integer, m::Integer, rng::AbstractRNG)
     x = Array(Float64, (k+1, m))
 
-    r = rand((k-1, m))
+    r = rand(rng, (k-1, m))
     x[1, :], x[2:end-1, :], x[end, :] = 0, sort(r, 1), 1
     return diff(x, 1)
 end
+
+random_probvec(k::Integer, m::Integer, seed::Integer) =
+    random_probvec(k, m, MersenneTwister(seed))
+
+random_probvec(k::Integer, m::Integer) =
+    random_probvec(k, m, Base.Random.GLOBAL_RNG)

--- a/src/random_mc.jl
+++ b/src/random_mc.jl
@@ -4,9 +4,14 @@ Generate a MarkovChain randomly.
 @author : Daisuke Oyama
 
 =#
-import Base.Random: GLOBAL_RNG
 import StatsBase: sample
 import QuantEcon: MarkovChain
+
+if VERSION < v"0.4-"
+    const GLOBAL_RNG = MersenneTwister()
+else
+    const GLOBAL_RNG = Base.Random.GLOBAL_RNG
+end
 
 
 # random_markov_chain

--- a/src/random_mc.jl
+++ b/src/random_mc.jl
@@ -4,6 +4,7 @@ Generate a MarkovChain randomly.
 @author : Daisuke Oyama
 
 =#
+import Base.Random: GLOBAL_RNG
 import StatsBase: sample
 import QuantEcon: MarkovChain
 
@@ -165,7 +166,7 @@ Return m randomly sampled probability vectors of size k.
 - `a::Array` : Array of shape (k, m) containing probability vectors as colums.
 
 """
-function random_probvec(k::Integer, m::Integer, rng::AbstractRNG)
+function random_probvec(k::Integer, m::Integer, rng::AbstractRNG=GLOBAL_RNG)
     x = Array(Float64, (k+1, m))
 
     r = rand(rng, (k-1, m))
@@ -175,6 +176,3 @@ end
 
 random_probvec(k::Integer, m::Integer, seed::Integer) =
     random_probvec(k, m, MersenneTwister(seed))
-
-random_probvec(k::Integer, m::Integer) =
-    random_probvec(k, m, Base.Random.GLOBAL_RNG)

--- a/src/random_mc.jl
+++ b/src/random_mc.jl
@@ -7,12 +7,6 @@ Generate a MarkovChain randomly.
 import StatsBase: sample
 import QuantEcon: MarkovChain
 
-if VERSION < v"0.4-"
-    const GLOBAL_RNG = MersenneTwister()
-else
-    const GLOBAL_RNG = Base.Random.GLOBAL_RNG
-end
-
 
 # random_markov_chain
 
@@ -164,20 +158,16 @@ Return m randomly sampled probability vectors of size k.
 
 - `k::Integer` : Number of probability vectors.
 - `m::Integer` : Size of each probability vectors.
-- `rng::AbstractRNG` : (Optional) Random number generator
 
 ##### Returns
 
 - `a::Array` : Array of shape (k, m) containing probability vectors as colums.
 
 """
-function random_probvec(k::Integer, m::Integer, rng::AbstractRNG=GLOBAL_RNG)
+function random_probvec(k::Integer, m::Integer)
     x = Array(Float64, (k+1, m))
 
-    r = rand(rng, (k-1, m))
+    r = rand(k-1, m)
     x[1, :], x[2:end-1, :], x[end, :] = 0, sort(r, 1), 1
     return diff(x, 1)
 end
-
-random_probvec(k::Integer, m::Integer, seed::Integer) =
-    random_probvec(k, m, MersenneTwister(seed))

--- a/src/random_mc.jl
+++ b/src/random_mc.jl
@@ -21,6 +21,21 @@ Return a randomly sampled MarkovChain instance with n states.
 
 - `mc::MarkovChain` : MarkovChain instance.
 
+##### Examples
+
+```julia
+julia> using QuantEcon
+
+julia> mc = random_markov_chain(3)
+Discrete Markov Chain
+stochastic matrix:
+3x3 Array{Float64,2}:
+ 0.281188  0.61799   0.100822
+ 0.144461  0.848179  0.0073594
+ 0.360115  0.323973  0.315912
+
+```
+
 """
 function random_markov_chain(n::Integer)
     p = random_stochastic_matrix(n)
@@ -40,6 +55,21 @@ has k states with positive transition probability.
 ##### Returns
 
 - `mc::MarkovChain` : MarkovChain instance.
+
+##### Examples
+
+```julia
+julia> using QuantEcon
+
+julia> mc = random_markov_chain(3, 2)
+Discrete Markov Chain
+stochastic matrix:
+3x3 Array{Float64,2}:
+ 0.369124  0.0       0.630876
+ 0.519035  0.480965  0.0
+ 0.0       0.744614  0.255386
+
+```
 
 """
 function random_markov_chain(n::Integer, k::Integer)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,7 @@ include("test_mc_tools.jl")
 include("test_models.jl")
 include("test_quad.jl")
 include("test_quadsum.jl")
+include("test_random_mc.jl")
 include("test_robustlq.jl")
 
 exitstatus()

--- a/test/test_random_mc.jl
+++ b/test/test_random_mc.jl
@@ -11,10 +11,10 @@ facts("Testing random_mc.jl") do
         mc_dicts = (@compat Dict("P" => random_markov_chain(n).p, "k" => n),
                     @compat Dict("P" => random_markov_chain(n, k).p, "k" => k))
         for d in mc_dicts
-            @fact size(d["P"]) --> (n, n)
-            for i in 1:size(d["P"])[1]
-                @fact countnz(d["P"][i, :]) --> d["k"]
-            end
+            P = d["P"]
+            @fact size(P) --> (n, n)
+            @fact all(x->(countnz(x)==d["k"]),
+                      [P[i, :] for i in 1:size(P)[1]]) --> true
         end
     end
 

--- a/test/test_random_mc.jl
+++ b/test/test_random_mc.jl
@@ -1,0 +1,43 @@
+module TestRandomMC
+
+using QuantEcon
+using Base.Test
+using FactCheck
+using Compat
+
+facts("Testing random_mc.jl") do
+    context("Test random_markov_chain") do
+        n, k = 5, 3
+        mc_dicts = (@compat Dict("P" => random_markov_chain(n).p, "k" => n),
+                    @compat Dict("P" => random_markov_chain(n, k).p, "k" => k))
+        for d in mc_dicts
+            @fact size(d["P"]) --> (n, n)
+            for i in 1:size(d["P"])[1]
+                @fact countnz(d["P"][i, :]) --> d["k"]
+            end
+        end
+    end
+
+    context("Test random_stochastic_matrix") do
+        n, k = 5, 3
+        Ps = (random_stochastic_matrix(n), random_stochastic_matrix(n, k))
+        for P in Ps
+            @fact all(P .>= 0) --> true
+            @fact all(x->isapprox(sum(x), 1),
+                      [P[i, :] for i in 1:size(P)[1]]) --> true
+        end
+    end
+
+    context("Test errors properly thrown") do
+        # n <= 0
+        @fact_throws random_markov_chain(0)
+
+        # k <= 0
+        @fact_throws random_markov_chain(2, 0)
+
+        # k > n
+        @fact_throws random_markov_chain(2, 3)
+    end
+end  # facts
+
+end  # module


### PR DESCRIPTION
This is the Julia version of PR QuantEcon/QuantEcon.py#154.
I hope this will be useful when we conduct performance checks.

Examples:

```julia
julia> using QuantEcon

julia> mc = random_markov_chain(3)
Discrete Markov Chain
stochastic matrix:
3x3 Array{Float64,2}:
 0.281188  0.61799   0.100822 
 0.144461  0.848179  0.0073594
 0.360115  0.323973  0.315912 


julia> mc = random_markov_chain(3, 2)
Discrete Markov Chain
stochastic matrix:
3x3 Array{Float64,2}:
 0.369124  0.0       0.630876
 0.519035  0.480965  0.0     
 0.0       0.744614  0.255386


```

* Sparse matrix is not supported yet.
* Random seed is not supported: the main reason is that `StatsBase.sample` [[source](https://github.com/JuliaStats/StatsBase.jl/blob/master/src/sampling.jl)] seems not to accept an `rng` argument. I only have `random_probvec` accept `rng` and `seed`, just to demonstrate how it would look like. See also the discussion QuantEcon/QuantEcon.py#153 in the Python side.
* In `random_probvec`, probability vectors are stored as columns, just because Julia is column-majored. In `random_stochastic_matrix`, the resulting matrix is transposed when returned. I am not sure if this is a good strategy, though.

Any comments/suggestions will be appreciated.
