### PR TITLE
change unicode to ascii for latex parsing

### DIFF
--- a/src/lqcontrol.jl
+++ b/src/lqcontrol.jl
@@ -292,7 +292,7 @@ function _compute_sequence{T}(lq::LQ, x0::Vector{T}, policies)
 end
 
 """
-Compute and return the optimal state and control sequence, assuming w ∼ N(0,1)
+Compute and return the optimal state and control sequence, assuming w ~ N(0,1)
 
 ##### Arguments
 


### PR DESCRIPTION
@spencerlyon2 This is a small change to allow the lectures to compile the ``pdf`` file. The unicode character was causing compilation issues. 