### PR TITLE
BUG: Fix bug in probvec

### DIFF
--- a/src/random_mc.jl
+++ b/src/random_mc.jl
@@ -164,6 +164,9 @@ Return m randomly sampled probability vectors of size k.
 
 """
 function random_probvec(k::Integer, m::Integer)
+    k == 1 && return ones((k, m))
+
+    # if k >= 2
     x = Array(Float64, (k, m))
 
     r = rand(k-1, m)

--- a/src/random_mc.jl
+++ b/src/random_mc.jl
@@ -155,8 +155,8 @@ Return m randomly sampled probability vectors of size k.
 
 ##### Arguments
 
-- `k::Integer` : Number of probability vectors.
-- `m::Integer` : Size of each probability vectors.
+- `k::Integer` : Size of each probability vector.
+- `m::Integer` : Number of probability vectors.
 
 ##### Returns
 

--- a/test/test_random_mc.jl
+++ b/test/test_random_mc.jl
@@ -28,6 +28,14 @@ facts("Testing random_mc.jl") do
         end
     end
 
+    context("Test random_stochastic_matrix with k=1") do
+        n, k = 3, 1
+        P = random_stochastic_matrix(n, k)
+        @fact all((P .== 0) | (P .== 1)) --> true
+        @fact all(x->isequal(sum(x), 1),
+                  [P[i, :] for i in 1:size(P)[1]]) --> true
+    end
+
     context("Test errors properly thrown") do
         # n <= 0
         @fact_throws random_markov_chain(0)


### PR DESCRIPTION
For `k=1`, `probvec` (and hence `random_stochastic_matrix` and `random_markov_chain`) raises an error with version 0.4, due to the change in the behavior of `sort`.

Version 0.4.1:

```julia
julia> k, m = 1, 3;

julia> r = rand(k-1, m)
0x3 Array{Float64,2}

julia> sort(r, 1)
ERROR: ArgumentError: step cannot be zero
 in steprange_last at /Applications/Julia-0.4.1.app/Contents/Resources/julia/lib/julia/sys.dylib
 in sort_chunks! at sort.jl:495
 in sort at sort.jl:489

```

Version 0.3.11:

```julia
julia> k, m = 1, 3;

julia> r = rand(k-1, m)
0x3 Array{Float64,2}

julia> sort(r, 1)
0x3 Array{Float64,2}

```

Fix by handling the case of `k=1` separately.
