### PR TITLE
ddp: Re-implement 3-dim matrix * vector

### DIFF
--- a/src/markov/ddp.jl
+++ b/src/markov/ddp.jl
@@ -388,14 +388,19 @@ Matrix multiplication over the last dimension of A
 
 =#
 function *{T}(A::Array{T,3}, v::Vector)
-    size(A, 3) ==  size(v, 1) || error("wrong dimensions")
-    out = Array(T, size(A)[1:2])
+    n1, n2, n3 = size(A)
+    size(v, 1) == n3 || error("wrong dimensions")
+    out = Array(T, n1, n2)
+    N = n1 * n2
 
-    # TODO: slicing A[i, j, :] is cache-unfriendly
-    for j=1:size(out, 2), i=1:size(out, 1)
-        out[i, j] = dot(A[i, j, :][:], v)
+    for i in 1:N
+        out[i] = A[i] * v[1]
     end
-    out
+    for k in 2:n1, i in 1:N
+        out[i] += A[(k-1)*N+i] * v[k]
+    end
+
+    return out
 end
 
 


### PR DESCRIPTION
I was reading [this article](http://julialang.org/blog/2013/09/fast-numeric/), and applied the tips of "Write cache-friendly codes" there to `*` in `ddp.jl`.

* This operation itself became 10x faster: see [this notebook](http://nbviewer.jupyter.org/gist/oyamad/75c9630268278d8d54c8).

* Overall `solve` became 2x-3x faster:
  * [current version](http://nbviewer.jupyter.org/gist/oyamad/c161449d73a620d53ff8/random_ddp_jl01.ipynb)
  * [this version](http://nbviewer.jupyter.org/gist/oyamad/c161449d73a620d53ff8/random_ddp_jl02.ipynb)

I am not sure if such a local optimization as this makes much sense, but open this PR for discussion.