### PR TITLE
ddp: Re-implement 3-dim matrix * vector with reshape

### DIFF
--- a/src/markov/ddp.jl
+++ b/src/markov/ddp.jl
@@ -388,14 +388,13 @@ Matrix multiplication over the last dimension of A
 
 =#
 function *{T}(A::Array{T,3}, v::Vector)
-    size(A, 3) ==  size(v, 1) || error("wrong dimensions")
-    out = Array(T, size(A)[1:2])
+    shape = size(A)
+    size(v, 1) == shape[end] || error("wrong dimensions")
 
-    # TODO: slicing A[i, j, :] is cache-unfriendly
-    for j=1:size(out, 2), i=1:size(out, 1)
-        out[i, j] = dot(A[i, j, :][:], v)
-    end
-    out
+    B = reshape(A, (prod(shape[1:end-1]), shape[end]))
+    out = B * v
+
+    return reshape(out, shape[1:end-1])
 end
 
 


### PR DESCRIPTION
Replaces #85. This is even faster (except for small-size arrays) and simpler.
* [`reduce_last2`](http://nbviewer.jupyter.org/gist/oyamad/75c9630268278d8d54c8/reduce_last_jl02.ipynb)

The speed of `solve` is more or less the same or slightly faster.
* [this version](http://nbviewer.jupyter.org/gist/oyamad/c161449d73a620d53ff8/random_ddp_jl03.ipynb)