### PR TITLE
Change type in meshgrid function

### DIFF
--- a/src/markov/ddp.jl
+++ b/src/markov/ddp.jl
@@ -388,14 +388,13 @@ Matrix multiplication over the last dimension of A
 
 =#
 function *{T}(A::Array{T,3}, v::Vector)
-    size(A, 3) ==  size(v, 1) || error("wrong dimensions")
-    out = Array(T, size(A)[1:2])
+    shape = size(A)
+    size(v, 1) == shape[end] || error("wrong dimensions")
 
-    # TODO: slicing A[i, j, :] is cache-unfriendly
-    for j=1:size(out, 2), i=1:size(out, 1)
-        out[i, j] = dot(A[i, j, :][:], v)
-    end
-    out
+    B = reshape(A, (prod(shape[1:end-1]), shape[end]))
+    out = B * v
+
+    return reshape(out, shape[1:end-1])
 end
 
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -7,8 +7,8 @@ Utility functions used in the QuantEcon library
 
 =#
 
-meshgrid(x::Vector, y::Vector) = (repmat(x, 1, length(y))',
-                                  repmat(y, 1, length(x)))
+meshgrid(x::AbstractVector, y::AbstractVector) = (repmat(x, 1, length(y))',
+                                                  repmat(y, 1, length(x)))
 
 # function to return a Range object with points equivalent to calling
 # linspace(x_min, x_max, n_x). This is needed because we often use

--- a/test/test_ddp.jl
+++ b/test/test_ddp.jl
@@ -59,7 +59,9 @@ facts("Testing markov/dpp.jl") do
 
         for f in (bellman_operator, compute_greedy)
             for T in float_types
-                @fact f(ddp0, [1.0, 1.0]) --> f(ddp0, ones(T, 2))
+                f_f64 = f(ddp0, [1.0, 1.0])
+                f_T = f(ddp0, ones(T, 2))
+                @fact f_f64 --> roughly(convert(Vector{eltype(f_f64)}, f_T))
             end
 
             # only Integer subtypes can be Rational type params
@@ -128,14 +130,14 @@ facts("Testing markov/dpp.jl") do
     end
 
     context("test DiscreteDP{Rational,_,_,Rational} maintains Rational") do
-        ddp_rational = DiscreteDP(map(Rational{Int128}, R),
-                                  map(Rational{Int128}, Q),
-                                  map(Rational{Int128}, beta))
+        ddp_rational = DiscreteDP(map(Rational{BigInt}, R),
+                                  map(Rational{BigInt}, Q),
+                                  map(Rational{BigInt}, beta))
         # do minimal number of iterations to avoid overflow
-        vi = Rational{Int128}[1/2, 1/2]
-        @fact eltype(solve(ddp_rational, VFI; max_iter=1, epsilon=Inf).v) --> Rational{Int128}
-        @fact eltype(solve(ddp_rational, vi, PFI; max_iter=1).v) --> Rational{Int128}
-        @fact eltype(solve(ddp_rational, vi, MPFI; max_iter=1, k=1, epsilon=Inf).v) --> Rational{Int128}
+        vi = Rational{BigInt}[1//2, 1//2]
+        @fact eltype(solve(ddp_rational, VFI; max_iter=1, epsilon=Inf).v) --> Rational{BigInt}
+        @fact eltype(solve(ddp_rational, vi, PFI; max_iter=1).v) --> Rational{BigInt}
+        @fact eltype(solve(ddp_rational, vi, MPFI; max_iter=1, k=1, epsilon=Inf).v) --> Rational{BigInt}
     end
 
     context("test DiscreteDP{Rational{BigInt},_,_,Rational{BigInt}}  works") do


### PR DESCRIPTION
Changes the types of the function arguments in `meshgrid` from `Vector` to `AbstractVector`.