### PR TITLE
don't need to include compat in tests anymore

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,3 @@
-using Compat  # for startswith
 using QuantEcon
 using DataStructures: counter
 using Distributions: LogNormal, pdf


### PR DESCRIPTION
@spencerlyon2 this isn't needed anymore in the tests as it isn't used