### PR TITLE
Implement faster gridmake

### DIFF
--- a/src/QuantEcon.jl
+++ b/src/QuantEcon.jl
@@ -1,4 +1,4 @@
-VERSION >= v"0.4.0-dev+6521" && __precompile__()
+__precompile__()
 
 module QuantEcon
 
@@ -84,8 +84,7 @@ export
     smooth, periodogram, ar_periodogram,
 
 # util
-    meshgrid,
-    linspace_range,
+    meshgrid, gridmake, gridmake!, ckron,
 
 # robustlq
     RBLQ,
@@ -99,7 +98,6 @@ export
     qnwlege, qnwcheb, qnwsimp, qnwtrap, qnwbeta, qnwgamma, qnwequi, qnwnorm,
     qnwunif, qnwlogn,
     quadrect,
-    gridmake,
     do_quad,
 
 # quadsums

--- a/src/quad.jl
+++ b/src/quad.jl
@@ -14,52 +14,6 @@ Miranda, Mario J, and Paul L Fackler. Applied Computational Economics
 and Finance, MIT Press, 2002.
 =#
 
-## ---------------- ##
-#- Helper Functions -#
-## ---------------- ##
-
-function fix!{T <: Real}(x::Array{T}, out::Array{Int})
-    for i=1:length(x)  # use linear indexing
-        out[i] = fix(x[i])
-    end
-    return out
-end
-
-fix{T <: Real}(x::Array{T}) = fix!(x, similar(x, Int))
-
-fix{T <: Real}(x::T) = round(Int, x >= 0 ? floor(x) : ceil(x))
-
-ckron(A::Array, B::Array) = kron(A, B)
-ckron(arrays::Array...) = reduce(kron, arrays)
-
-
-# TODO: this gridmake works, but I don't like it.
-function gridmake(arrays::Vector...)
-    shapes = Int[size(e, 1) for e in arrays]
-
-    n = length(arrays)
-    l = prod(shapes)
-    out = Array(Float64, l, n)
-
-    shapes = shapes[end:-1:1]
-    sh = vcat([1], shapes[1:end-1]...)
-    repititions = cumprod(sh)
-    repititions = repititions[end:-1:1]
-
-    for i=1:n
-        arr = arrays[i]
-        outer = repititions[i]
-        inner = round(Int, floor(l / (outer * size(arr, 1))))
-        out[:, i] = repeat(arrays[i], inner=[inner], outer=[outer])
-    end
-    return out
-end
-
-
-## ------------------ ##
-#- Exported Functions -#
-## ------------------ ##
-
 const qnw_func_notes = """
 ##### Notes
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -6,12 +6,55 @@ Utility functions used in the QuantEcon library
 @date: 2014-08-14
 
 =#
-
 meshgrid(x::AbstractVector, y::AbstractVector) = (repmat(x, 1, length(y))',
                                                   repmat(y, 1, length(x)))
 
-# function to return a Range object with points equivalent to calling
-# linspace(x_min, x_max, n_x). This is needed because we often use
-# CoordInterpGrid from Grid.jl for interpolation and that requires a
-# range to be passed as the first argument
-linspace_range(x_min, x_max, n_x) = x_min:(x_max - x_min) / (n_x  - 1): x_max
+fix(x::Real) = x >= 0 ? floor(Int, x) : ceil(Int, x)
+fix!{T<:Real}(x::AbstractArray{T}, out::Array{Int}) = map!(fix, out, x)
+fix{T<:Real}(x::AbstractArray{T}) = fix!(x, similar(x, Int))
+
+ckron(A::Array, B::Array) = kron(A, B)
+ckron(arrays::Array...) = reduce(kron, arrays)
+
+function gridmake!(out, arrays::AbstractVector...)
+    arr = arrays[1]
+    typ = eltype(arr)
+    l = 1; for a in arrays; l *= length(a); end
+    n = length(arrays)
+    @assert size(out) == (l, n)
+
+    l_i = length(arr)
+    m = Int(l / l_i)
+
+    # fill this column
+    row = 1
+    @inbounds for el in arr, i = 1:m
+        out[row, 1] = el
+        row += 1
+    end
+
+    if n > 1
+        # recursively call to fill upper right block for columns 2:end
+        gridmake!(sub(out, 1:m, 2:n), arrays[2:end]...)
+
+        # extract upper right block and fill in lower middle block for columns
+        # 2:end
+        @inbounds for j in 2:l_i
+            out[(j-1)*m+1:(j)*m, 2:end] = sub(out, 1:m, 2:n)
+        end
+    end
+    out
+end
+
+function gridmake(arrays::AbstractVector...)
+    l = prod([length(a) for a in  arrays])
+    T = reduce(promote_type, [eltype(a) for a in arrays])
+    gridmake!(Array(T, l, length(arrays)), arrays...)
+    out
+end
+
+# type stable version if all arrays have the same eltype
+function gridmake{T}(arrays::AbstractVector{T}...)
+    out = Array(T, prod([length(a) for a in  arrays]), length(arrays))
+    gridmake!(out, arrays...)
+end

--- a/test/test_quad.jl
+++ b/test/test_quad.jl
@@ -30,21 +30,6 @@ x_unif_1, w_unif_1 = qnwunif(n, a, b)
 x_beta_1, w_beta_1 = qnwbeta(n, b, b+1)
 x_gamm_1, w_gamm_1 = qnwgamma(n, b)
 
-# 3-d nodes and weights
-x_cheb_3, w_cheb_3 = qnwcheb(n_3, a_3, b_3)
-x_equiN_3, w_equiN_3 = qnwequi(n_3, a_3, b_3, "N")
-x_equiW_3, w_equiW_3 = qnwequi(n_3, a_3, b_3, "W")
-x_equiH_3, w_equiH_3 = qnwequi(n_3, a_3, b_3, "H")
-# rng(42); x_equiR_3, w_equiR_3 = qnwequi(n_3, a_3, b_3, "R")
-x_lege_3, w_lege_3 = qnwlege(n_3, a_3, b_3)
-x_norm_3, w_norm_3 = qnwnorm(n_3, mu_3d, sigma2_3d)
-x_logn_3, w_logn_3 = qnwlogn(n_3, mu_3d, sigma2_3d)
-x_simp_3, w_simp_3 = qnwsimp(n_3, a_3, b_3)
-x_trap_3, w_trap_3 = qnwtrap(n_3, a_3, b_3)
-x_unif_3, w_unif_3 = qnwunif(n_3, a_3, b_3)
-x_beta_3, w_beta_3 = qnwbeta(n_3, b_3, b_3+1.0)
-x_gamm_3, w_gamm_3 = qnwgamma(n_3, b_3, ones(3))
-
 @testset "Testing quad.jl" begin
 
     @testset "Testing method resolution" begin
@@ -72,15 +57,13 @@ x_gamm_3, w_gamm_3 = qnwgamma(n_3, b_3, ones(3))
         # generate names
         for name in ["cheb", "equiN", "equiW", "equiH", "lege", "norm",
                      "logn", "simp", "trap", "unif", "beta", "gamm"]
-            for d in [1, 3]
-                x_str_name = "x_$(name)_$(d)"
-                w_str_name = "w_$(name)_$(d)"
-                jl_x, jl_w = eval(symbol(x_str_name)), eval(symbol(w_str_name))
-                ml_x, ml_w = m[x_str_name],  m[w_str_name]
-                ml_x = d == 3 ? ml_x : squeeze(ml_x, 2)
-                @test isapprox(jl_x, ml_x; atol=1e-5)
-                @test isapprox(jl_w, squeeze(ml_w, 2); atol=1e-5)
-            end
+            x_str_name = "x_$(name)_1"
+            w_str_name = "w_$(name)_1"
+            jl_x, jl_w = eval(symbol(x_str_name)), eval(symbol(w_str_name))
+            ml_x, ml_w = m[x_str_name],  m[w_str_name]
+            ml_x = squeeze(ml_x, 2)
+            @test isapprox(jl_x, ml_x; atol=1e-5)
+            @test isapprox(jl_w, squeeze(ml_w, 2); atol=1e-5)
         end
     end
 

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -1,0 +1,45 @@
+@testset "util.jl" begin
+
+    @testset "gridmake" begin
+        want = [1  4  6
+                1  4  7
+                1  5  6
+                1  5  7
+                2  4  6
+                2  4  7
+                2  5  6
+                2  5  7
+                3  4  6
+                3  4  7
+                3  5  6
+                3  5  7]
+
+        # test allocating version
+        @test want == @inferred gridmake([1, 2, 3], [4, 5], [6, 7])
+
+        # test non-allocating version
+        out = zeros(Int, 12, 3)
+        @inferred gridmake!(out, [1, 2, 3], [4, 5], [6, 7])
+        @test out == want
+
+        # test single array version returns matrix of same type
+        @test gridmake([1, 2, 3]) == [1 2 3]'
+
+        # make sure we get the error we were expecting
+        @test_throws AssertionError gridmake!(zeros(Int, 2, 2), [1, 2, 3], [4, 5])
+    end
+
+    @testset "fix" begin
+        @test 1 == @inferred fix(1.2)
+        @test [0, 2] == @inferred fix([0.9, 2.1])
+        @test [0, 2] == @inferred fix([0, 2])
+
+        out = [100, 100]
+        @inferred fix!([0, 2], out)
+        @test [0, 2] == out
+
+        @test [0 2; 2 0] == @inferred fix([0.5 2.9999; 3-2eps() -0.9])
+    end
+
+    @test ([1 2; 1 2], [3 3; 4 4]) == @inferred meshgrid([1, 2], [3, 4])
+end


### PR DESCRIPTION
Minor PR to implement a faster version of `gridmake` as well as implement a mutating version.

Also added some tests.

NOTE: this is breaking because previously we had the first array varying the fastest, now we have the last array varying the fastest. I don't believe this should cause problems for anyone, but if it does let me know and we'll do the other implementation.

- - -

A quick benchmark comparison:

```
julia> a1, a2, a3 = randn(10), randn(10), randn(10);

julia> @benchmark gridmake1(a1, a2, a3)
Benchmarks.ExecutionResults:
  samples:                          (see :samples field)
  precompiled?:                     true
  multiple evaluations per sample?: false
  total time spent benchmarking:    0.48 s
  Benchmarks.SummaryStats:
    estimated time per evaluation: 4.25 ms [3.34 ms, 5.17 ms]
    R² of OLS model:               N/A (OLS not performed)
    estimated % time in GC:        1.96 % [0.0 %, 7.9 %]
    bytes allocated:               819.83 kb
    number of allocations:         25104
    number of samples:             100
    number of evaluations:         100

julia> @benchmark gridmake(a1, a2, a3)
Benchmarks.ExecutionResults:
  samples:                          (see :samples field)
  precompiled?:                     true
  multiple evaluations per sample?: true
  total time spent benchmarking:    10.77 s
  Benchmarks.SummaryStats:
    estimated time per evaluation: 16.13 μs [15.73 μs, 16.52 μs]
    R² of OLS model:               0.91
    estimated % time in GC:        5.52 % [4.3 %, 6.74 %]
    bytes allocated:               26.61 kb
    number of allocations:         71
    number of samples:             6101
    number of evaluations:         670901
```

Here `gridmake` is the new version and `gridmake1` is the old version. This scales better and better the larger the input arrays.