### PR TITLE
Add `stationary_distributions`

### DIFF
--- a/src/QuantEcon.jl
+++ b/src/QuantEcon.jl
@@ -41,7 +41,7 @@ export
 
 # mc_tools
     MarkovChain,
-    mc_compute_stationary, stationary_distributions,
+    stationary_distributions,
     simulate, simulate!, simulate_values, simulate_values!,
     simulation, value_simulation,
     period, is_irreducible, is_aperiodic, recurrent_classes,

--- a/src/QuantEcon.jl
+++ b/src/QuantEcon.jl
@@ -41,7 +41,7 @@ export
 
 # mc_tools
     MarkovChain,
-    mc_compute_stationary,
+    mc_compute_stationary, stationary_distributions,
     simulate, simulate!, simulate_values, simulate_values!,
     simulation, value_simulation,
     period, is_irreducible, is_aperiodic, recurrent_classes,

--- a/src/markov/mc_tools.jl
+++ b/src/markov/mc_tools.jl
@@ -244,8 +244,9 @@ for (S, ex_T, ex_gth) in ((Real, :(T), :(gth_solve!)),
             dist = zeros(T1, n)
             # * mc.p[rec_class, rec_class] is a copy, hence gth_solve!
             #   while gth_solve for Int matrix
-            # * full is to convert a sparse matrix to a dense matrix
-            A = full(mc.p[rec_class, rec_class])
+            # * todense is to convert a sparse matrix to a dense matrix
+            #   with eltype T1
+            A = todense(T1, mc.p[rec_class, rec_class])
             dist[rec_class] = $ex_gth(A)
             stationary_dists[i] = dist
         end
@@ -269,6 +270,24 @@ recurrent class.
   `Int` (and equal to `T` otherwise).
 
 """ stationary_distributions
+
+
+"""Custom version of `full`, which allows convertion to type T"""
+# From base/sparse/sparsematrix.jl
+function todense(T::Type, S::SparseMatrixCSC)
+    A = zeros(T, S.m, S.n)
+    for Sj in 1:S.n
+        for Sk in nzrange(S, Sj)
+            Si = S.rowval[Sk]
+            Sv = S.nzval[Sk]
+            A[Si, Sj] = Sv
+        end
+    end
+    return A
+end
+
+"""If A is already dense, return A as is"""
+todense(::Type, A::Array) = A
 
 
 """

--- a/src/markov/mc_tools.jl
+++ b/src/markov/mc_tools.jl
@@ -224,21 +224,7 @@ function mc_compute_stationary{T}(mc::MarkovChain{T})
     return stationary_dists
 end
 
-"""
-Compute stationary distributions of the Markov chain `mc`, one for each
-recurrent class.
 
-##### Arguments
-
-- `mc::MarkovChain{T}` : MarkovChain instance.
-
-##### Returns
-
-- `stationary_dists::Vector{Vector{T1}}` : Array of vectors that represent
-  stationary distributions, where the element type `T1` is `Rational` is `T` is
-  `Int` (and equal to `T` otherwise).
-
-"""
 for (S, ex) in ((Real, :(T)), (Integer, :(Rational{T})))
     @eval function stationary_distributions{T<:$S}(mc::MarkovChain{T})
         n = n_states(mc)
@@ -260,6 +246,22 @@ for (S, ex) in ((Real, :(T)), (Integer, :(Rational{T})))
         return stationary_dists
     end
 end
+
+@doc """
+Compute stationary distributions of the Markov chain `mc`, one for each
+recurrent class.
+
+##### Arguments
+
+- `mc::MarkovChain{T}` : MarkovChain instance.
+
+##### Returns
+
+- `stationary_dists::Vector{Vector{T1}}` : Array of vectors that represent
+  stationary distributions, where the element type `T1` is `Rational` is `T` is
+  `Int` (and equal to `T` otherwise).
+
+""" stationary_distributions
 
 
 """

--- a/src/markov/mc_tools.jl
+++ b/src/markov/mc_tools.jl
@@ -239,24 +239,26 @@ recurrent class.
   `Int` (and equal to `T` otherwise).
 
 """
-function stationary_distributions{T<:Real}(mc::MarkovChain{T})
-    n = n_states(mc)
-    rec_classes = recurrent_classes(mc)
-    T1 = ifelse(T <: Integer, Rational{T}, T)  # TODO: Resolve type-instability
-    stationary_dists = Array(Vector{T1}, length(rec_classes))
+for (S, ex) in ((Real, :(T)), (Integer, :(Rational{T})))
+    @eval function stationary_distributions{T<:$S}(mc::MarkovChain{T})
+        n = n_states(mc)
+        rec_classes = recurrent_classes(mc)
+        T1 = $ex
+        stationary_dists = Array(Vector{T1}, length(rec_classes))
 
-    if length(rec_classes) == 1  # unique recurrent class
-        stationary_dists[1] = gth_solve(mc.p)
-    else  # more than one recurrent classes
-        for i in 1:length(rec_classes)
-            rec_class = rec_classes[i]
-            dist = zeros(T1, n)
-            dist[rec_class] = gth_solve(sub(mc.p, rec_class, rec_class))
-            stationary_dists[i] = dist
+        if length(rec_classes) == 1  # unique recurrent class
+            stationary_dists[1] = gth_solve(mc.p)
+        else  # more than one recurrent classes
+            for i in 1:length(rec_classes)
+                rec_class = rec_classes[i]
+                dist = zeros(T1, n)
+                dist[rec_class] = gth_solve(sub(mc.p, rec_class, rec_class))
+                stationary_dists[i] = dist
+            end
         end
-    end
 
-    return stationary_dists
+        return stationary_dists
+    end
 end
 
 

--- a/src/markov/mc_tools.jl
+++ b/src/markov/mc_tools.jl
@@ -225,6 +225,42 @@ function mc_compute_stationary{T}(mc::MarkovChain{T})
 end
 
 """
+Compute stationary distributions of the Markov chain `mc`, one for each
+recurrent class.
+
+##### Arguments
+
+- `mc::MarkovChain{T}` : MarkovChain instance.
+
+##### Returns
+
+- `stationary_dists::Vector{Vector{T1}}` : Array of vectors that represent
+  stationary distributions, where the element type `T1` is `Rational` is `T` is
+  `Int` (and equal to `T` otherwise).
+
+"""
+function stationary_distributions{T<:Real}(mc::MarkovChain{T})
+    n = n_states(mc)
+    rec_classes = recurrent_classes(mc)
+    T1 = ifelse(T <: Integer, Rational{T}, T)  # TODO: Resolve type-instability
+    stationary_dists = Array(Vector{T1}, length(rec_classes))
+
+    if length(rec_classes) == 1  # unique recurrent class
+        stationary_dists[1] = gth_solve(mc.p)
+    else  # more than one recurrent classes
+        for i in 1:length(rec_classes)
+            rec_class = rec_classes[i]
+            dist = zeros(T1, n)
+            dist[rec_class] = gth_solve(sub(mc.p, rec_class, rec_class))
+            stationary_dists[i] = dist
+        end
+    end
+
+    return stationary_dists
+end
+
+
+"""
 Simulate time series of state transitions of the Markov chain `mc`.
 
 The sample path from the `j`-th repetition of the simulation with initial state

--- a/src/markov/mc_tools.jl
+++ b/src/markov/mc_tools.jl
@@ -18,14 +18,16 @@ import LightGraphs: DiGraph, period, attracting_components,
 """
 Finite-state discrete-time Markov chain.
 
-It stores useful information such as the stationary distributions, and
-communication, recurrent, and cyclic classes, and allows simulation of state
-transitions.
+Methods are available that provide useful information such as the stationary
+distributions, and communication and recurrent classes, and allow simulation of
+state transitions.
 
 ##### Fields
 
-- `p::Matrix` The transition matrix. Must be square, all elements must be
-positive, and all rows must sum to unity
+- `p::AbstractMatrix` : The transition matrix. Must be square, all elements
+must be nonnegative, and all rows must sum to unity.
+- `state_values::AbstractVector` : Vector containing the values associated with
+the states.
 """
 type MarkovChain{T, TM<:AbstractMatrix, TV<:AbstractVector}
     p::TM # valid stochastic matrix
@@ -57,13 +59,13 @@ end
 MarkovChain(p::AbstractMatrix, state_values=1:size(p, 1)) =
     MarkovChain{eltype(p), typeof(p), typeof(state_values)}(p, state_values)
 
-"Number of states in the markov chain `mc`"
+"Number of states in the Markov chain `mc`"
 n_states(mc::MarkovChain) = size(mc.p, 1)
 
 function Base.show{T,TM}(io::IO, mc::MarkovChain{T,TM})
     println(io, "Discrete Markov Chain")
     println(io, "stochastic matrix of type $TM:")
-    println(io, mc.p)
+    print(io, mc.p)
 end
 
 """
@@ -128,63 +130,75 @@ function gth_solve{T<:Real}(original::AbstractMatrix{T})
 end
 
 """
-Find the recurrent classes of the `MarkovChain`
+Find the recurrent classes of the Markov chain `mc`.
 
 ##### Arguments
 
-- `mc::MarkovChain` : MarkovChain instance containing a valid stochastic matrix
+- `mc::MarkovChain` : MarkovChain instance.
 
 ##### Returns
 
-- `x::Vector{Vector}`: A `Vector` containing `Vector{Int}`s that describe the
-recurrent classes of the transition matrix for p
+- `::Vector{Vector{Int}}` : Vector of vectors that describe the recurrent
+classes of `mc`.
 
 """
 recurrent_classes(mc::MarkovChain) = attracting_components(DiGraph(mc.p))
 
 """
-A communication class of the Markov Chain `X_t` or of the stochastic matrix `p`
-is a strongly connected component of the directed graph associated with `p`
+Find the communication classes of the Markov chain `mc`.
 
 #### Arguments
 
-- `mc::MarkovChain` MarkovChain instance containing a valid stochastic matrix
+- `mc::MarkovChain` : MarkovChain instance.
 
 ### Returns
 
-- `x::Vector{Vector{Int64}}` An array of the associated strongly connected components
+- `::Vector{Vector{Int}}` : Vector of vectors that describe the communication
+classes of `mc`.
 
 """
 communication_classes(mc::MarkovChain) = strongly_connected_components(DiGraph(mc.p))
 
 """
-Indicate whether the Markov chain is irreducible.
+Indicate whether the Markov chain `mc` is irreducible.
 
 ##### Arguments
 
-- `mc::MarkovChain` : MarkovChain instance containing a valid stochastic matrix
+- `mc::MarkovChain` : MarkovChain instance.
 
 ##### Returns
 
-- Bool (true or false)
+- `::Bool`
 
 """
 is_irreducible(mc::MarkovChain) =  is_strongly_connected(DiGraph(mc.p))
 
 """
-Indicate whether the Markov chain is aperiodic.
+Indicate whether the Markov chain `mc` is aperiodic.
 
 ##### Arguments
 
-- `mc::MarkovChain` : MarkovChain instance containing a valid stochastic matrix
+- `mc::MarkovChain` : MarkovChain instance.
 
 ##### Returns
 
-- Bool (true or false)
+- `::Bool`
 
 """
 is_aperiodic(mc::MarkovChain) = period(mc) == 1
 
+"""
+Return the period of the Markov chain `mc`.
+
+##### Arguments
+
+- `mc::MarkovChain` : MarkovChain instance.
+
+##### Returns
+
+- `::Int` : Period of `mc`.
+
+"""
 function period(mc::MarkovChain)
     g = DiGraph(mc.p)
     recurrent = attracting_components(g)
@@ -257,8 +271,8 @@ recurrent class.
 
 ##### Returns
 
-- `stationary_dists::Vector{Vector{T1}}` : Array of vectors that represent
-  stationary distributions, where the element type `T1` is `Rational` is `T` is
+- `stationary_dists::Vector{Vector{T1}}` : Vector of vectors that represent
+  stationary distributions, where the element type `T1` is `Rational` if `T` is
   `Int` (and equal to `T` otherwise).
 
 """ stationary_distributions
@@ -276,12 +290,12 @@ The sample path from the `j`-th repetition of the simulation with initial state
 - `ts_length::Int` : Length of each simulation.
 - `init::Vector{Int}` : Vector containing initial states.
 - `;num_reps::Int(1)` : Number of repetitions of simulation for each element
-of `init`
+of `init`.
 
 ##### Returns
 
 - `X::Matrix{Int}` : Array containing the sample paths as columns, of shape
-(ts_length, k), where k = length(init)* num_reps
+(ts_length, k), where k = length(init)* num_reps.
 
 """
 function simulate(mc::MarkovChain, ts_length::Int, init::Vector{Int};
@@ -302,12 +316,12 @@ Simulate time series of state transitions of the Markov chain `mc`.
 - `mc::MarkovChain` : MarkovChain instance.
 - `ts_length::Int` : Length of each simulation.
 - `init::Int` : Initial state.
-- `;num_reps::Int(1)` : Number of repetitions of simulation
+- `;num_reps::Int(1)` : Number of repetitions of simulation.
 
 ##### Returns
 
 - `X::Matrix{Int}` : Array containing the sample paths as columns, of shape
-(ts_length, k), where k = num_reps
+(ts_length, k), where k = num_reps.
 
 """
 simulate(mc::MarkovChain, ts_length::Int, init::Int; num_reps::Int=1) =
@@ -325,7 +339,7 @@ Simulate time series of state transitions of the Markov chain `mc`.
 ##### Returns
 
 - `X::Matrix{Int}` : Array containing the sample paths as columns, of shape
-(ts_length, k), where k = num_reps
+(ts_length, k), where k = num_reps.
 
 """
 function simulate(mc::MarkovChain, ts_length::Int; num_reps::Int=1)
@@ -373,7 +387,7 @@ Simulate time series of state transitions of the Markov chain `mc`.
 
 ##### Returns
 
-- `x::Vector`: A vector of transition indices for a single simulation
+- `x::Vector`: A vector of transition indices for a single simulation.
 """
 function simulation(mc::MarkovChain, ts_length::Int,
                     init_state::Int=rand(1:n_states(mc)))
@@ -430,7 +444,7 @@ end
 @doc """ Like `simulate(::MarkovChain, args...; kwargs...)`, but instead of
 returning integers specifying the state indices, this routine returns the
 values of the `mc.state_values` at each of those indices. See docstring
-for `simulate` for more information
+for `simulate` for more information.
 """ simulate_values, simulate_values!
 
 
@@ -445,7 +459,7 @@ Simulate time series of state transitions of the Markov chain `mc`.
 
 ##### Returns
 
-- `x::Vector`: A vector of state values along a simulated path
+- `x::Vector`: A vector of state values along a simulated path.
 """
 function value_simulation(mc::MarkovChain, ts_length::Int,
                           init_state::Int=rand(1:n_states(mc)))

--- a/src/markov/mc_tools.jl
+++ b/src/markov/mc_tools.jl
@@ -89,7 +89,7 @@ University Press, 2009.
 
 """
 gth_solve{T<:Integer}(a::AbstractMatrix{T}) =
-    gth_solve(convert(AbstractArray{Rational, 2}, a))
+    gth_solve(convert(AbstractArray{Rational{T}, 2}, a))
 
 # solve x(P-I)=0 by the GTH method
 function gth_solve{T<:Real}(original::AbstractMatrix{T})

--- a/src/markov/mc_tools.jl
+++ b/src/markov/mc_tools.jl
@@ -202,12 +202,14 @@ Return the period of the Markov chain `mc`.
 function period(mc::MarkovChain)
     g = DiGraph(mc.p)
     recurrent = attracting_components(g)
-    periods   = Int[]
 
+    d = 1
     for r in recurrent
-        push!(periods, period(g[r]))
+        pd = period(g[r])
+        d *= div(pd, gcd(pd, d))
     end
-    return lcm(periods)
+
+    return d
 end
 """
 calculate the stationary distributions associated with a N-state markov chain

--- a/src/markov/mc_tools.jl
+++ b/src/markov/mc_tools.jl
@@ -69,19 +69,35 @@ function Base.show{T,TM}(io::IO, mc::MarkovChain{T,TM})
 end
 
 """
-solve x(P-I)=0 using an algorithm presented by Grassmann-Taksar-Heyman (GTH)
+This routine computes the stationary distribution of an irreducible Markov
+transition matrix (stochastic matrix) or transition rate matrix (generator
+matrix) `A`.
+
+More generally, given a Metzler matrix (square matrix whose off-diagonal
+entries are all nonnegative) `A`, this routine solves for a nonzero solution
+`x` to `x (A - D) = 0`, where `D` is the diagonal matrix for which the rows of
+`A - D` sum to zero (i.e., `D_{ii} = \sum_j A_{ij}` for all `i`). One (and only
+one, up to normalization) nonzero solution exists corresponding to each
+reccurent class of `A`, and in particular, if `A` is irreducible, there is a
+unique solution; when there are more than one solution, the routine returns the
+solution that contains in its support the first index `i` such that no path
+connects `i` to any index larger than `i`. The solution is normalized so that
+its 1-norm equals one. This routine implements the Grassmann-Taksar-Heyman
+(GTH) algorithm (Grassmann, Taksar, and Heyman 1985), a numerically stable
+variant of Gaussian elimination, where only the off-diagonal entries of `A` are
+used as the input data. For a nice exposition of the algorithm, see Stewart
+(2009), Chapter 10.
 
 ##### Arguments
 
-- `p::Matrix` : valid stochastic matrix
+- `A::Matrix{T}` : Stochastic matrix or generator matrix. Must be of shape n x
+  n.
 
 ##### Returns
 
-- `x::Matrix`: A matrix whose columns contain stationary vectors of `p`
+- `x::Vector{T}` : Stationary distribution of `A`.
 
 ##### References
-
-The following references were consulted for the GTH algorithm
 
 - W. K. Grassmann, M. I. Taksar and D. P. Heyman, "Regenerative Analysis and
 Steady State Distributions for Markov Chains, " Operations Research (1985),
@@ -96,6 +112,10 @@ gth_solve{T<:Real}(A::Matrix{T}) = gth_solve!(copy(A))
 gth_solve{T<:Integer}(A::Matrix{T}) =
     gth_solve!(convert(Matrix{Rational{T}}, A))
 
+"""
+Same as `gth_solve`, but overwrite the input `A`, instead of creating a copy.
+
+"""
 function gth_solve!{T<:Real}(A::Matrix{T})
     n = size(A, 1)
     x = zeros(T, n)

--- a/src/markov/mc_tools.jl
+++ b/src/markov/mc_tools.jl
@@ -230,34 +230,6 @@ function period(mc::MarkovChain)
 
     return d
 end
-"""
-calculate the stationary distributions associated with a N-state markov chain
-
-##### Arguments
-
-- `mc::MarkovChain` : MarkovChain instance containing a valid stochastic matrix
-
-##### Returns
-
-- `dists::Matrix{Float64}`: N x M matrix where each column is a stationary
-distribution of `mc.p`
-
-"""
-function mc_compute_stationary{T}(mc::MarkovChain{T})
-    recurrent = recurrent_classes(mc)
-
-    # unique recurrent class
-    length(recurrent) == 1 && return gth_solve(mc.p)
-
-    # more than one recurrent classes
-    stationary_dists = Array(T, n_states(mc), length(recurrent))
-    for (i, class) in enumerate(recurrent)
-        dist        = zeros(T, n_states(mc))
-        dist[class] = gth_solve(mc.p[class, class]) # recast to correct dimension
-        stationary_dists[:, i] = dist
-    end
-    return stationary_dists
-end
 
 
 for (S, ex_T, ex_gth) in ((Real, :(T), :(gth_solve!)),

--- a/test/test_mc_tools.jl
+++ b/test/test_mc_tools.jl
@@ -95,6 +95,12 @@ end
         @test mc_compute_stationary(mc10) == mc10_stationary
     end
 
+    @testset "test mc_compute_stationary with reducible mc with integers" begin
+        mc_int = MarkovChain([0 1 0; 1 0 0; 0 0 1])
+        mc_int_stationary = [1//2  0//1; 1//2  0//1; 0//1  1//1]
+        @test mc_compute_stationary(mc_int) == mc_int_stationary
+    end
+
     @testset "test stationary_distributions" begin
         mc_int = MarkovChain([0 1 0; 1 0 0; 0 0 1])
         mc_int_stationary_dists = Vector[[1//2,1//2,0//1], [0//1,0//1,1//1]]

--- a/test/test_mc_tools.jl
+++ b/test/test_mc_tools.jl
@@ -304,61 +304,7 @@ end
         end
     end
 
-    # these matrices come from RMT4 section 2.2.1
-    mc1 = [1 0 0; .2 .5 .3; 0 0 1]
-    mc2 = [.7 .3 0; 0 .5 .5; 0 .9 .1]
-    mc3 = [0.4 0.6; 0.2 0.8]
-    mc4 = eye(2)
-    mc5 = [
-         0 1 0 0 0 0
-         1 0 0 0 0 0
-         1//2 0 0 1//2 0 0
-         0 0 0 0 1 0
-         0 0 0 0 0 1
-         0 0 0 1 0 0
-         ]
-    mc5_stationary = zeros(Rational,6,2)
-    mc5_stationary[[1,2]] = 1//2; mc5_stationary[[10,11,12]] = 1//3
-
-    mc6 = [2//3 1//3; 1//4 3//4]  # Rational elements
-    mc6_stationary = [3//7, 4//7]
-
-    mc7 = [1 0; 0 1]
-    mc7_stationary = [1 0;0 1]
-
-    # Reducible mc with a unique recurrent class,
-    # where n=2 is a transient state
-    mc10 = [1. 0; 1. 0]
-    mc10_stationary = [1., 0]
-
-    mc1 = MarkovChain(mc1)
-    mc2 = MarkovChain(mc2)
-    mc3 = MarkovChain(mc3)
-    mc4 = MarkovChain(mc4)
-    mc5 = MarkovChain(mc5)
-    mc6 = MarkovChain(mc6)
-    mc7 = MarkovChain(mc7)
-    mc10 = MarkovChain(mc10)
-
     tol = 1e-15
-
-    @testset "test mc_compute_stationary using exact solutions" begin
-        @test mc_compute_stationary(mc1) == eye(3)[:, [1, 3]]
-        @test isapprox(mc_compute_stationary(mc2), [0, 9/14, 5/14])
-        @test isapprox(mc_compute_stationary(mc3), [1/4, 3/4])
-        @test mc_compute_stationary(mc4) == eye(2)
-        @test mc_compute_stationary(mc5) == mc5_stationary
-        @test mc_compute_stationary(mc6) == mc6_stationary
-        @test mc_compute_stationary(mc7) == mc7_stationary
-        @test mc_compute_stationary(mc10) == mc10_stationary
-    end
-
-    @testset "test mc_compute_stationary with reducible mc with integers" begin
-        mc_int = MarkovChain([0 1 0; 1 0 0; 0 0 1])
-        mc_int_stationary = [1//2  0//1; 1//2  0//1; 0//1  1//1]
-        @test mc_compute_stationary(mc_int) == mc_int_stationary
-    end
-
     kmr_matrices = (
         kmr_markov_matrix_sequential(27, 1/3, 1e-2),
         kmr_markov_matrix_sequential(3, 1/3, 1e-14)
@@ -413,6 +359,8 @@ end
         # negative element, but sums to 1
         @test_throws ArgumentError MarkovChain([-1 1; 0.2 0.8])
     end
+
+    mc3 = MarkovChain([0.4 0.6; 0.2 0.8])
 
     @testset "test simulate shape" begin
 

--- a/test/test_mc_tools.jl
+++ b/test/test_mc_tools.jl
@@ -168,7 +168,7 @@ end
     @testset "test MarkovChain with Float64" begin
         for test_dict in testcases_Float64
             mc = MarkovChain(test_dict["P"])
-            stationary_dists = stationary_distributions(mc)
+            stationary_dists = @inferred stationary_distributions(mc)
             @test isapprox(stationary_dists, test_dict["stationary_dists"])
             @test isequal(
                 sort(communication_classes(mc), by=(x->x[1])),
@@ -203,7 +203,7 @@ end
     @testset "test MarkovChain with Rational" begin
         for test_dict in testcases_Rational
             mc = MarkovChain(test_dict["P"])
-            stationary_dists = stationary_distributions(mc)
+            stationary_dists = @inferred stationary_distributions(mc)
             @test isequal(stationary_dists, test_dict["stationary_dists"])
             @test isequal(
                 sort(communication_classes(mc), by=(x->x[1])),
@@ -265,7 +265,7 @@ end
     @testset "test MarkovChain with Int" begin
         for test_dict in testcases_Int
             mc = MarkovChain(test_dict["P"])
-            stationary_dists = stationary_distributions(mc)
+            stationary_dists = @inferred stationary_distributions(mc)
             @test isequal(stationary_dists, test_dict["stationary_dists"])
             @test isequal(
                 sort(communication_classes(mc), by=(x->x[1])),
@@ -288,7 +288,7 @@ end
                                                          testcases_Rational,
                                                          testcases_Int)]
             mc = MarkovChain(sparse(test_dict["P"]))
-            stationary_dists = stationary_distributions(mc)
+            stationary_dists = @inferred stationary_distributions(mc)
             @test isapprox(stationary_dists, test_dict["stationary_dists"])
             @test isequal(
                 sort(communication_classes(mc), by=(x->x[1])),

--- a/test/test_mc_tools.jl
+++ b/test/test_mc_tools.jl
@@ -327,6 +327,35 @@ end
         end
     end
 
+    @testset "test gth_solve with generator matrices" begin
+        P_dict_Int = Dict(
+            "P" => [-3 3; 4 -4],
+            "stationary_dist" => [4//7, 3//7],
+        )
+
+        P_dict_Float64 = Dict(
+            "P" => [-3. 3.; 4. -4.],
+            "stationary_dist" => [4/7, 3/7],
+        )
+
+        x = gth_solve(P_dict_Int["P"])
+        @test isequal(x, P_dict_Int["stationary_dist"])
+
+        x = gth_solve(P_dict_Float64["P"])
+        @test isapprox(x, P_dict_Float64["stationary_dist"])
+    end
+
+    @testset "test gth_solve with reducible matrix" begin
+        P_dict = Dict(
+            "P" => [0.4 0 0.6 0; 0 0 0 1; 0.2 0 0.8 0; 0 1 0 0],
+            # Stationary dist for the recurrent class {1, 3}
+            "stationary_dist" => [0.25, 0, 0.75, 0],
+        )
+
+        x = gth_solve(P_dict["P"])
+        @test isapprox(x, P_dict["stationary_dist"])
+    end
+
     @testset "test MarkovChain with KMR matrices" begin
         for P in kmr_matrices
             mc = MarkovChain(P)

--- a/test/test_mc_tools.jl
+++ b/test/test_mc_tools.jl
@@ -95,6 +95,12 @@ end
         @test mc_compute_stationary(mc10) == mc10_stationary
     end
 
+    @testset "test stationary_distributions" begin
+        mc_int = MarkovChain([0 1 0; 1 0 0; 0 0 1])
+        mc_int_stationary_dists = Vector[[1//2,1//2,0//1], [0//1,0//1,1//1]]
+        @test stationary_distributions(mc_int) == mc_int_stationary_dists
+    end
+
     @testset "test gth_solve with KMR matrices" begin
         for d in [mc8,mc9]
             x = mc_compute_stationary(d)

--- a/test/test_mc_tools.jl
+++ b/test/test_mc_tools.jl
@@ -1,31 +1,308 @@
 function kmr_markov_matrix_sequential{T<:Real}(n::Integer, p::T, ε::T)
     """
-    Generate the MarkovChain with the associated transition matrix from the KMR model with *sequential* move
+    Generate the markov matrix for the KMR model with *sequential* move
 
     n: number of players
-    p: level of p-dominance for action 1
-       = the value of p such that action 1 is the BR for (1-q, q) for any q > p,
-         where q (1-q, resp.) is the prob that the opponent plays action 1 (0, resp.)
+    p: level of p-dominance for action 2
+       = the value of p such that action 2 is the BR for (1-q, q) for any q > p,
+         where q (1-q, resp.) is the prob that the opponent plays action 2 (1, resp.)
     ε: mutation probability
 
     References:
-        KMRMarkovMatrixSequential is contributed from https://github.com/oyamad
+        kmr_markov_matrix_sequential is contributed from https://github.com/oyamad
     """
-    x = zeros(T, n+1, n+1)
+    P = zeros(T, n+1, n+1)
 
-    x[1, 1], x[1, 2] = 1 - ε/2, ε/2
+    P[1, 1], P[1, 2] = 1 - ε/2, ε/2
     @inbounds for i = 1:n-1
-        x[i+1, i] = (i/n) * (ε/2 + (1 - ε) *
+        P[i+1, i] = (i/n) * (ε/2 + (1 - ε) *
                              (((i-1)/(n-1) < p) + ((i-1)/(n-1) == p)/2))
-        x[i+1, i+2] = ((n-i)/n) * (ε/2 + (1 - ε) *
+        P[i+1, i+2] = ((n-i)/n) * (ε/2 + (1 - ε) *
                                  ((i/(n-1) > p) + (i/(n-1) == p)/2))
-        x[i+1, i+1] = 1 - x[i+1, i] - x[i+1, i+2]
+        P[i+1, i+1] = 1 - P[i+1, i] - P[i+1, i+2]
     end
-    x[end, end-1], x[end, end] = ε/2, 1 - ε/2
-    return MarkovChain(x)
+    P[end, end-1], P[end, end] = ε/2, 1 - ε/2
+    return P
 end
 
+
+function Base.isapprox{T<:Real,S<:Real}(x::Vector{Vector{T}},
+                                        y::Vector{Vector{S}})
+    n = length(x)
+    length(y) == n || return false
+    for i in 1:n
+        isapprox(x[i], y[i])::Bool || return false
+    end
+    return true
+end
+
+
 @testset "Testing mc_tools.jl" begin
+    # Matrix with two recurrent classes [1, 2] and [4, 5, 6],
+    # which have periods 2 and 3, respectively
+    Q = [0 1 0 0 0 0
+         1 0 0 0 0 0
+         1//2 0 0 1//2 0 0
+         0 0 0 0 1 0
+         0 0 0 0 0 1
+         0 0 0 1 0 0]
+    Q_stationary_dists = Vector{Rational{Int}}[
+        [1//2, 1//2, 0, 0, 0, 0], [0, 0, 0, 1//3, 1//3, 1//3]
+    ]
+    Q_dict_Rational = Dict(
+        "P" => Q,
+        "stationary_dists" => Q_stationary_dists,
+        "comm_classes" => Vector{Int}[[1, 2], [3], [4, 5, 6]],
+        "rec_classes" => Vector{Int}[[1, 2], [4, 5, 6]],
+        "is_irreducible" => false,
+        "period" => 6,
+        "is_aperiodic" => false,
+    )
+    Q_dict_Float64 = copy(Q_dict_Rational)
+    Q_dict_Float64["P"] = convert(Matrix{Float64}, Q)
+    Q_dict_Float64["stationary_dists"] =
+        convert(Vector{Vector{Float64}}, Q_stationary_dists)
+
+    # examples from
+    # Graph-Theoretic Analysis of Finite Markov Chains by J.P. Jarvis & D. R. Shier
+
+    fig1_p = zeros(Rational{Int64}, 5, 5)
+    fig1_p[[3, 4, 9, 10, 11, 13, 18, 19, 22, 24]] =
+        [1//2, 2//5, 1//10, 1, 1, 1//5, 3//10, 1//5, 1, 3//10]
+    fig2_p = zeros(Rational{Int64}, 5, 5)
+    fig2_p[[3, 10, 11, 13, 14, 17, 18, 19, 22]] =
+        [1//3, 1, 1, 1//3, 1//2, 1//2, 1//3, 1//2, 1//2]
+
+    fig1_dict_Rational = Dict(
+        "P" => fig1_p,
+        "stationary_dists" => Vector{Rational{Int}}[[0, 1//2, 0, 0, 1//2]],
+        "comm_classes" => Vector{Int}[[1, 3, 4], [2, 5]],
+        "rec_classes" => Vector{Int}[[2, 5]],
+        "is_irreducible" => false,
+        "period" => 2,
+        "is_aperiodic" => false,
+    )
+    fig2_dict_Rational = Dict(
+        "P" => fig2_p,
+        "stationary_dists" => Vector{Rational{Int}}[[1//6, 0, 3//6, 2//6, 0]],
+        "comm_classes" => Vector{Int}[[1, 3, 4], [2, 5]],
+        "rec_classes" => Vector{Int}[[1, 3, 4]],
+        "is_irreducible" => false,
+        "period" => 1,
+        "is_aperiodic" => true,
+    )
+    fig1_dict_Float64 = copy(fig1_dict_Rational)
+    fig2_dict_Float64 = copy(fig2_dict_Rational)
+    for (d_R, d_F) in zip((fig1_dict_Rational, fig2_dict_Rational),
+                          (fig1_dict_Float64, fig2_dict_Float64))
+        d_F["P"] = convert(Matrix{Float64}, d_R["P"])
+        d_F["stationary_dists"] =
+            convert(Vector{Vector{Float64}}, d_R["stationary_dists"])
+    end
+
+    testcases_Float64 = [
+        Q_dict_Float64,
+        Dict(
+            "P" => [0.4 0.6; 0.2 0.8],
+            "stationary_dists" => Vector{Float64}[[0.25, 0.75]],
+            "comm_classes" => Vector{Int}[collect(1:2)],
+            "rec_classes" => Vector{Int}[collect(1:2)],
+            "is_irreducible" => true,
+            "period" => 1,
+            "is_aperiodic" => true,
+            # "cyclic_classes" => Vector[collect(1:2)],
+        ),
+        Dict(
+            "P" => [0. 1.; 1. 0.],
+            "stationary_dists" => Vector{Float64}[[0.5, 0.5]],
+            "comm_classes" => Vector{Int}[collect(1:2)],
+            "rec_classes" => Vector{Int}[collect(1:2)],
+            "is_irreducible" => true,
+            "period" => 2,
+            "is_aperiodic" => false,
+            # "cyclic_classes" => Vector[[1], [2]],
+        ),
+        Dict(
+            "P" => eye(2),
+            "stationary_dists" => Vector{Float64}[[1, 0], [0, 1]],
+            "comm_classes" => Vector{Int}[[1], [2]],
+            "rec_classes" => Vector{Int}[[1], [2]],
+            "is_irreducible" => false,
+            "period" => 1,
+            "is_aperiodic" => true,
+        ),
+        # Reducible mc with a unique recurrent class,
+        # where n-1 is a transient state
+        Dict(
+            "P" => [1. 0.; 1. 0.],
+            "stationary_dists" => Vector{Float64}[[1, 0]],
+            "comm_classes" => Vector{Int}[[1], [2]],
+            "rec_classes" => Vector{Int}[[1]],
+            "is_irreducible" => false,
+            "period" => 1,
+            "is_aperiodic" => true,
+        ),
+        # these matrices come from RMT4 section 2.2.1
+        Dict(
+            "P" => [1 0 0; .2 .5 .3; 0 0 1],
+            "stationary_dists" => Vector{Float64}[[1, 0, 0], [0, 0, 1]],
+            "comm_classes" => Vector{Int}[[1], [2], [3]],
+            "rec_classes" => Vector{Int}[[1], [3]],
+            "is_irreducible" => false,
+            "period" => 1,
+            "is_aperiodic" => true,
+        ),
+        Dict(
+            "P" => [.7 .3 0; 0 .5 .5; 0 .9 .1],
+            "stationary_dists" => Vector{Float64}[[0, 9/14, 5/14]],
+            "comm_classes" => Vector{Int}[[1], [2, 3]],
+            "rec_classes" => Vector{Int}[[2, 3]],
+            "is_irreducible" => false,
+            "period" => 1,
+            "is_aperiodic" => true,
+        ),
+        fig1_dict_Float64,
+        fig2_dict_Float64,
+    ]
+
+    @testset "test MarkovChain with Float64" begin
+        for test_dict in testcases_Float64
+            mc = MarkovChain(test_dict["P"])
+            stationary_dists = stationary_distributions(mc)
+            @test isapprox(stationary_dists, test_dict["stationary_dists"])
+            @test isequal(
+                sort(communication_classes(mc), by=(x->x[1])),
+                test_dict["comm_classes"]
+                )
+            @test isequal(
+                sort(recurrent_classes(mc), by=(x->x[1])),
+                test_dict["rec_classes"]
+                )
+            @test is_irreducible(mc) == test_dict["is_irreducible"]
+            @test period(mc) == test_dict["period"]
+            @test is_aperiodic(mc) == test_dict["is_aperiodic"]
+        end
+    end
+
+    testcases_Rational = [
+        Q_dict_Rational,
+        Dict(
+            "P" => [2//3 1//3; 1//4 3//4],
+            "stationary_dists" => Vector{Rational{Int}}[[3//7, 4//7]],
+            "comm_classes" => Vector{Int}[collect(1:2)],
+            "rec_classes" => Vector{Int}[collect(1:2)],
+            "is_irreducible" => true,
+            "period" => 1,
+            "is_aperiodic" => true,
+            # "cyclic_classes" => Vector[collect(1:2)],
+        ),
+        fig1_dict_Rational,
+        fig2_dict_Rational,
+    ]
+
+    @testset "test MarkovChain with Rational" begin
+        for test_dict in testcases_Rational
+            mc = MarkovChain(test_dict["P"])
+            stationary_dists = stationary_distributions(mc)
+            @test isequal(stationary_dists, test_dict["stationary_dists"])
+            @test isequal(
+                sort(communication_classes(mc), by=(x->x[1])),
+                test_dict["comm_classes"]
+                )
+            @test isequal(
+                sort(recurrent_classes(mc), by=(x->x[1])),
+                test_dict["rec_classes"]
+                )
+            @test is_irreducible(mc) == test_dict["is_irreducible"]
+            @test period(mc) == test_dict["period"]
+            @test is_aperiodic(mc) == test_dict["is_aperiodic"]
+        end
+    end
+
+    testcases_Int = [
+        Dict(
+            "P" => [0 1; 1 0],
+            "stationary_dists" => Vector{Rational{Int}}[[1//2, 1//2]],
+            "comm_classes" => Vector{Int}[collect(1:2)],
+            "rec_classes" => Vector{Int}[collect(1:2)],
+            "is_irreducible" => true,
+            "period" => 2,
+            "is_aperiodic" => false,
+            # "cyclic_classes" => Vector[[1], [2]],
+        ),
+        Dict(
+            "P" => eye(Int, 2),
+            "stationary_dists" => Vector{Rational{Int}}[[1, 0], [0, 1]],
+            "comm_classes" => Vector{Int}[[1], [2]],
+            "rec_classes" => Vector{Int}[[1], [2]],
+            "is_irreducible" => false,
+            "period" => 1,
+            "is_aperiodic" => true,
+        ),
+        # Reducible mc with a unique recurrent class,
+        # where n-1 is a transient state
+        Dict(
+            "P" => [1 0; 1 0],
+            "stationary_dists" => Vector{Rational{Int}}[[1, 0]],
+            "comm_classes" => Vector{Int}[[1], [2]],
+            "rec_classes" => Vector{Int}[[1]],
+            "is_irreducible" => false,
+            "period" => 1,
+            "is_aperiodic" => true,
+        ),
+        Dict(
+            "P" => [0 1 0; 1 0 0; 0 0 1],
+            "stationary_dists" =>
+                Vector{Rational{Int}}[[1//2,1//2,0//1], [0//1,0//1,1//1]],
+            "comm_classes" => Vector{Int}[[1, 2], [3]],
+            "rec_classes" => Vector{Int}[[1, 2], [3]],
+            "is_irreducible" => false,
+            "period" => 2,
+            "is_aperiodic" => false,
+        ),
+    ]
+
+    @testset "test MarkovChain with Int" begin
+        for test_dict in testcases_Int
+            mc = MarkovChain(test_dict["P"])
+            stationary_dists = stationary_distributions(mc)
+            @test isequal(stationary_dists, test_dict["stationary_dists"])
+            @test isequal(
+                sort(communication_classes(mc), by=(x->x[1])),
+                test_dict["comm_classes"]
+                )
+            @test isequal(
+                sort(recurrent_classes(mc), by=(x->x[1])),
+                test_dict["rec_classes"]
+                )
+            @test is_irreducible(mc) == test_dict["is_irreducible"]
+            @test period(mc) == test_dict["period"]
+            @test is_aperiodic(mc) == test_dict["is_aperiodic"]
+        end
+    end
+
+    @testset "test Sparse MarkovChain" begin
+        # Test 2 testcases from each of testcases_*
+        for test_dict in [testcases[i] for i in 1:2,
+                                           testcases in (testcases_Float64,
+                                                         testcases_Rational,
+                                                         testcases_Int)]
+            mc = MarkovChain(sparse(test_dict["P"]))
+            stationary_dists = stationary_distributions(mc)
+            @test isapprox(stationary_dists, test_dict["stationary_dists"])
+            @test isequal(
+                sort(communication_classes(mc), by=(x->x[1])),
+                test_dict["comm_classes"]
+                )
+            @test isequal(
+                sort(recurrent_classes(mc), by=(x->x[1])),
+                test_dict["rec_classes"]
+                )
+            @test is_irreducible(mc) == test_dict["is_irreducible"]
+            @test period(mc) == test_dict["period"]
+            @test is_aperiodic(mc) == test_dict["is_aperiodic"]
+        end
+    end
 
     # these matrices come from RMT4 section 2.2.1
     mc1 = [1 0 0; .2 .5 .3; 0 0 1]
@@ -63,25 +340,6 @@ end
     mc7 = MarkovChain(mc7)
     mc10 = MarkovChain(mc10)
 
-    # examples from
-    # Graph-Theoretic Analysis of Finite Markov Chains by J.P. Jarvis & D. R. Shier
-
-    fig1_p = zeros(Rational{Int64}, 5, 5)
-    fig1_p[[3, 4, 9, 10, 11, 13, 18, 19, 22, 24]] =
-        [1//2, 2//5, 1//10, 1, 1, 1//5, 3//10, 1//5, 1, 3//10]
-    fig2_p = zeros(Rational{Int64}, 5, 5)
-    fig2_p[[3, 10, 11, 13, 14, 17, 18, 19, 22]] =
-        [1//3, 1, 1, 1//3, 1//2, 1//2, 1//3, 1//2, 1//2]
-
-    fig1 = MarkovChain(convert(Matrix{Float64}, fig1_p))
-    fig1_rat = MarkovChain(fig1_p)
-
-    fig2 = MarkovChain(convert(Matrix{Float64}, fig2_p))
-    fig2_rat = MarkovChain(fig2_p)
-
-    mc8 = kmr_markov_matrix_sequential(27, 1/3, 1e-2)
-    mc9 = kmr_markov_matrix_sequential(3, 1/3, 1e-14)
-
     tol = 1e-15
 
     @testset "test mc_compute_stationary using exact solutions" begin
@@ -101,15 +359,14 @@ end
         @test mc_compute_stationary(mc_int) == mc_int_stationary
     end
 
-    @testset "test stationary_distributions" begin
-        mc_int = MarkovChain([0 1 0; 1 0 0; 0 0 1])
-        mc_int_stationary_dists = Vector[[1//2,1//2,0//1], [0//1,0//1,1//1]]
-        @test @inferred(stationary_distributions(mc_int)) == mc_int_stationary_dists
-    end
+    kmr_matrices = (
+        kmr_markov_matrix_sequential(27, 1/3, 1e-2),
+        kmr_markov_matrix_sequential(3, 1/3, 1e-14)
+    )
 
     @testset "test gth_solve with KMR matrices" begin
-        for d in [mc8,mc9]
-            x = mc_compute_stationary(d)
+        for P in kmr_matrices
+            x = gth_solve(P)
 
             # Check elements sum to one
             @test isapprox(sum(x), 1; atol=tol)
@@ -120,7 +377,26 @@ end
             end
 
             # Check x is a left eigenvector of P
-            @test isapprox(vec(x'*d.p), x; atol=tol)
+            @test isapprox(vec(x'*P), x; atol=tol)
+        end
+    end
+
+    @testset "test MarkovChain with KMR matrices" begin
+        for P in kmr_matrices
+            mc = MarkovChain(P)
+            stationary_dists = stationary_distributions(mc)
+            for x in stationary_dists
+                # Check elements sum to one
+                @test isapprox(sum(x), 1; atol=tol)
+
+                # Check elements are nonnegative
+                for i in 1:length(x)
+                    @test x[i] >= -tol
+                end
+
+                # Check x is a left eigenvector of P
+                @test isapprox(vec(x'*P), x; atol=tol)
+            end
         end
     end
 
@@ -136,24 +412,6 @@ end
 
         # negative element, but sums to 1
         @test_throws ArgumentError MarkovChain([-1 1; 0.2 0.8])
-    end
-
-    @testset "test graph theoretic algorithms" begin
-        for fig in [fig1, fig1_rat]
-            @test recurrent_classes(fig) == Vector[[2, 5]]
-            @test communication_classes(fig) == Vector[[2, 5], [1, 3, 4]]
-            @test is_irreducible(fig) == false
-            # @test period(fig) == 2
-            # @test is_aperiodic(fig) == false
-        end
-
-        for fig in [fig2, fig2_rat]
-            @test recurrent_classes(fig) == Vector[[1, 3, 4]]
-            @test communication_classes(fig) == Vector[[1, 3, 4], [2, 5]]
-            @test is_irreducible(fig) == false
-            # @test period(fig) == 1
-            # @test is_aperiodic(fig) == true
-        end
     end
 
     @testset "test simulate shape" begin

--- a/test/test_mc_tools.jl
+++ b/test/test_mc_tools.jl
@@ -104,7 +104,7 @@ end
     @testset "test stationary_distributions" begin
         mc_int = MarkovChain([0 1 0; 1 0 0; 0 0 1])
         mc_int_stationary_dists = Vector[[1//2,1//2,0//1], [0//1,0//1,1//1]]
-        @test stationary_distributions(mc_int) == mc_int_stationary_dists
+        @test @inferred(stationary_distributions(mc_int)) == mc_int_stationary_dists
     end
 
     @testset "test gth_solve with KMR matrices" begin

--- a/test/test_mc_tools.jl
+++ b/test/test_mc_tools.jl
@@ -467,7 +467,8 @@ end
             @test is_irreducible(mc) == is_irreducible(mc_s)
             @test is_aperiodic(mc) == is_aperiodic(mc_s)
             @test period(mc) == period(mc_s)
-            @test maxabs(gth_solve(mc_s.p) - gth_solve(mc.p)) < 1e-15
+            @test isapprox(stationary_distributions(mc_s),
+                           stationary_distributions(mc))
         end
     end
 


### PR DESCRIPTION
1.
This is to add `stationary_distributions` for `MarkovChain`, which always returns stationary distributions as a Vector of Vectors (even when there is a unique stationary distribution), as in the Python version (EDIT: in the sense that the Python version does not change the dimension of output array regardless of the number of stationary distributions). This avoids first the type-instability and second the issue of whether to contain distributions as rows or columns when the return is a Matrix.

The current `mc_compute_stationary` returns a Vector when there is a unique recurrent class, and returns a Matrix when there are more than one.

2.
I need a help regarding the best way to determine the eltype of the output vectors. Consider a `MarkovChain{Int64}` with the stochastic matrix

```jl
[0 1 0;
 1 0 0;
 0 0 1]
```

By the feature of [`gth_solve{T<:Integer}(a::AbstractMatrix{T})`](https://github.com/QuantEcon/QuantEcon.jl/compare/stationary_distributions?expand=1#diff-16a555a93eb180b914e7f7be94d268f0R91), the returned vector has eltype `Rational`, so I have to change the eltype of the output vector accordingly, which is done [here](https://github.com/QuantEcon/QuantEcon.jl/compare/stationary_distributions?expand=1#diff-16a555a93eb180b914e7f7be94d268f0R245). But with this, `UNION` shows up in the output of `@code_warntype`. One way is to let `MarkovChain` not accept an integer matrix, but is there any better strategy?

`mc_compute_stationary` does not take care of this, so an error is raised in the test added.

3.
I would propose to deprecate `mc_compute_stationary`.

4.
Maybe better to rename `mc_tools.jl` to `markov_chain.jl` or `core.jl`?
