### PR TITLE
Fix indices overwr ddp

### DIFF
--- a/src/lqcontrol.jl
+++ b/src/lqcontrol.jl
@@ -276,23 +276,23 @@ function _compute_sequence{T}(lq::LQ, x0::Vector{T}, policies)
 
     x_path = Array(T, n, capT+1)
     u_path = Array(T, k, capT)
-    w_path = [vec(C*randn(j)) for i=1:(capT+1)]
+    w_path = C*randn(j, capT+1)
 
     x_path[:, 1] = x0
     u_path[:, 1] = -(first(policies)*x0)
 
     for t = 2:capT
         f = policies[t]
-        x_path[:, t] = A*x_path[: ,t-1] + B*u_path[:, t-1] + w_path[t]
+        x_path[:, t] = A*x_path[: ,t-1] + B*u_path[:, t-1] + w_path[:, t]
         u_path[:, t] = -(f*x_path[:, t])
     end
-    x_path[:, end] = A*x_path[:, capT] + B*u_path[:, capT] + w_path[end]
+    x_path[:, end] = A*x_path[:, capT] + B*u_path[:, capT] + w_path[:, end]
 
     x_path, u_path, w_path
 end
 
 """
-Compute and return the optimal state and control sequence, assuming w ~ N(0,1)
+Compute and return the optimal state and control sequence, assuming innovation N(0,1)
 
 ##### Arguments
 
@@ -308,8 +308,8 @@ only for `min(ts_length, lq.capT)`
 represents `x_t`
 - `u_path::Matrix{Float64}` : A k x T matrix, where the t-th column represents
 `u_t`
-- `w_path::Matrix{Float64}` : A j x T+1 matrix, where the t-th column represents
-`lq.C*w_t`
+- `w_path::Matrix{Float64}` : A n x T+1 matrix, where the t-th column represents
+`lq.C*N(0,1)`
 
 """
 function compute_sequence(lq::LQ, x0::ScalarOrArray, ts_length::Integer=100)

--- a/src/markov/ddp.jl
+++ b/src/markov/ddp.jl
@@ -36,8 +36,6 @@ DiscreteDP type for specifying paramters for discrete dynamic programming model
 - `R::Array{T,NR}` : Reward Array
 - `Q::Array{T,NQ}` : Transition Probability Array
 - `beta::Float64`  : Discount Factor
-- `s_indices::Nullable{Vector{Tind}}`: State Indices. Null unless using
-  SA formulation
 - `a_indices::Nullable{Vector{Tind}}`: Action Indices. Null unless using
   SA formulation
 - `a_indptr::Nullable{Vector{Tind}}`: Action Index Pointers. Null unless using
@@ -52,7 +50,6 @@ type DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind}
     R::Array{T,NR}                     # Reward Array
     Q::Array{T,NQ}                     # Transition Probability Array
     beta::Tbeta                        # Discount Factor
-    s_indices::Nullable{Vector{Tind}}  # State Indices
     a_indices::Nullable{Vector{Tind}}  # Action Indices
     a_indptr::Nullable{Vector{Tind}}   # Action Index Pointers
 
@@ -84,11 +81,10 @@ type DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind}
         end
 
         # here the indices and indptr are null.
-        _s_indices = Nullable{Vector{Int}}()
         _a_indices = Nullable{Vector{Int}}()
         a_indptr = Nullable{Vector{Int}}()
 
-        new(R, Q, beta, _s_indices, _a_indices, a_indptr)
+        new(R, Q, beta, _a_indices, a_indptr)
     end
 
     # Note: We left R, Q as type Array to produce more helpful error message with regards to shape.
@@ -121,7 +117,6 @@ type DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind}
         if _has_sorted_sa_indices(s_indices, a_indices)
             a_indptr = Array(Int64, num_states+1)
             _a_indices = copy(a_indices)
-            _s_indices = copy(s_indices)
             _generate_a_indptr!(num_states, s_indices, a_indptr)
         else
             # transpose matrix to use Julia's CSC; now rows are actions and
@@ -136,11 +131,6 @@ type DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind}
 
             R = R[as_ptr.nzval]
             Q = Q[as_ptr.nzval, :]
-
-            _s_indices = Array(eltype(_a_indices), num_sa_pairs)
-            for i in 1:num_states, j in a_indptr[i]:(a_indptr[i+1]-1)
-                _s_indices[j] = i
-            end
         end
 
         # check feasibility
@@ -153,11 +143,10 @@ type DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind}
         end
 
         # package into nullables before constructing type
-        _s_indices = Nullable{Vector{Tind}}(_s_indices)
         _a_indices = Nullable{Vector{Tind}}(_a_indices)
         a_indptr = Nullable{Vector{Tind}}(a_indptr)
 
-        new(R, full(Q), beta, _s_indices, _a_indices, a_indptr)
+        new(R, full(Q), beta, _a_indices, a_indptr)
     end
 end
 

--- a/src/markov/ddp.jl
+++ b/src/markov/ddp.jl
@@ -120,6 +120,8 @@ type DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind}
 
         if _has_sorted_sa_indices(s_indices, a_indices)
             a_indptr = Array(Int64, num_states+1)
+            _a_indices = copy(a_indices)
+            _s_indices = copy(s_indices)
             _generate_a_indptr!(num_states, s_indices, a_indptr)
         else
             # transpose matrix to use Julia's CSC; now rows are actions and

--- a/src/markov/ddp.jl
+++ b/src/markov/ddp.jl
@@ -84,11 +84,11 @@ type DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind}
         end
 
         # here the indices and indptr are null.
-        s_indices = Nullable{Vector{Int}}()
-        a_indices = Nullable{Vector{Int}}()
+        _s_indices = Nullable{Vector{Int}}()
+        _a_indices = Nullable{Vector{Int}}()
         a_indptr = Nullable{Vector{Int}}()
 
-        new(R, Q, beta, s_indices, a_indices, a_indptr)
+        new(R, Q, beta, _s_indices, _a_indices, a_indptr)
     end
 
     # Note: We left R, Q as type Array to produce more helpful error message with regards to shape.
@@ -129,17 +129,16 @@ type DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind}
             msg = "Duplicate s-a pair found"
             as_ptr = sparse(a_indices, s_indices, 1:num_sa_pairs, m, n,
                             (x,y)->throw(ArgumentError(msg)))
-            a_indices = as_ptr.rowval
+            _a_indices = as_ptr.rowval
             a_indptr = as_ptr.colptr
 
             R = R[as_ptr.nzval]
             Q = Q[as_ptr.nzval, :]
 
-            _s_indices = Array(eltype(a_indices), num_sa_pairs)
+            _s_indices = Array(eltype(_a_indices), num_sa_pairs)
             for i in 1:num_states, j in a_indptr[i]:(a_indptr[i+1]-1)
                 _s_indices[j] = i
             end
-            copy!(s_indices, _s_indices)
         end
 
         # check feasibility
@@ -152,11 +151,11 @@ type DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind}
         end
 
         # package into nullables before constructing type
-        s_indices = Nullable{Vector{Tind}}(s_indices)
-        a_indices = Nullable{Vector{Tind}}(a_indices)
+        _s_indices = Nullable{Vector{Tind}}(_s_indices)
+        _a_indices = Nullable{Vector{Tind}}(_a_indices)
         a_indptr = Nullable{Vector{Tind}}(a_indptr)
 
-        new(R, full(Q), beta, s_indices, a_indices, a_indptr)
+        new(R, full(Q), beta, _s_indices, _a_indices, a_indptr)
     end
 end
 


### PR DESCRIPTION
This commit fixes the overwriting of `s_indices` (and `a_indices`) when sorting, which prevented re-use of the same vectors. See #117 