### PR TITLE
bug fix in Markov chain simulation

### DIFF
--- a/src/markov/mc_tools.jl
+++ b/src/markov/mc_tools.jl
@@ -382,7 +382,7 @@ function simulate!(mc::MarkovChain, X::Matrix{Int})
 
     for i in 1:k
         for t in 1:ts_length-1
-            X[t+1, i] = draw(P_dist[X[t]])
+            X[t+1, i] = draw(P_dist[X[t,i]])
         end
     end
     X


### PR DESCRIPTION
With num_reps > 1 the t+1 draw of the chain was always using the distribution conditional on the value at t for the first repetition.