### PR TITLE
add minimum version requirement for Compat.view

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,4 +3,5 @@ DSP
 Distributions 0.8.9
 LightGraphs
 Primes
-Compat
+Compat 0.8.4
+StatsBase


### PR DESCRIPTION
also add StatsBase explicitly to REQUIRE, on the off-chance it's ever not available
as an indirect dependency