### PR TITLE
Upgraded code to handle 1 dimensional cases

### DIFF
--- a/src/matrix_eqn.jl
+++ b/src/matrix_eqn.jl
@@ -113,7 +113,7 @@ function solve_discrete_riccati(A::ScalarOrArray, B::ScalarOrArray,
     BTA = B' * A
 
     for gamma in candidates
-        Z = reshape(R + gamma .* BB, n, n)
+        Z = getZ(R, gamma, BB)
         cn = cond(Z)
         if isfinite(cn)
             Q_tilde = -Q + N' * (Z \ (N + gamma .* BTA)) + gamma .* I
@@ -168,3 +168,48 @@ function solve_discrete_riccati(A::ScalarOrArray, B::ScalarOrArray,
 
     return H0 + gamma .* I  # Return X
 end
+
+"""
+Simple method to return an element Z in the Riccati equation solver whose type is Float64 (to be accepted by the cond() function)
+
+##### Arguments
+
+- `BB::Float64` : result of B' * B
+- `gamma::Float64` : parameter in the Riccati equation solver
+- `R::Float64`
+
+##### Returns
+- `::Float64` : element Z in the Riccati equation solver
+
+"""
+getZ(R::Float64, gamma::Float64, BB::Float64) = R + gamma * BB
+
+"""
+Simple method to return an element Z in the Riccati equation solver whose type is Float64 (to be accepted by the cond() function)
+
+##### Arguments
+
+- `BB::Array{Float64, 1}` : result of B' * B
+- `gamma::Float64` : parameter in the Riccati equation solver
+- `R::Float64`
+
+##### Returns
+- `::Float64` : element Z in the Riccati equation solver
+
+"""
+getZ(R::Float64, gamma::Float64, BB::Array{Float64, 1}) = R + gamma * BB[1]
+
+"""
+Simple method to return an element Z in the Riccati equation solver whose type is Matrix (to be accepted by the cond() function)
+
+##### Arguments
+
+- `BB::Matrix` : result of B' * B
+- `gamma::Float64` : parameter in the Riccati equation solver
+- `R::Matrix`
+
+##### Returns
+- `::Matrix` : element Z in the Riccati equation solver
+
+"""
+getZ(R::Matrix, gamma::Float64, BB::Matrix) = R + gamma .* BB

--- a/src/matrix_eqn.jl
+++ b/src/matrix_eqn.jl
@@ -113,7 +113,7 @@ function solve_discrete_riccati(A::ScalarOrArray, B::ScalarOrArray,
     BTA = B' * A
 
     for gamma in candidates
-        Z = R + gamma .* BB
+        Z = reshape(R + gamma .* BB, n, n)
         cn = cond(Z)
         if isfinite(cn)
             Q_tilde = -Q + N' * (Z \ (N + gamma .* BTA)) + gamma .* I


### PR DESCRIPTION
When fixing the notebook `lqcontrol_solutions_jl` I encountered a situation where matrix `Z` on this line https://github.com/QuantEcon/QuantEcon.jl/blob/master/src/matrix_eqn.jl#L116 is actually an `Array{Float64, 1}` with a single element (as `R` is a scalar). As `Base.cond` requires a matrix, this commit makes `Z` into a comformable `Array{Float64, 2}` always.