### PR TITLE
Minor issue with warnings

### DIFF
--- a/src/compute_fp.jl
+++ b/src/compute_fp.jl
@@ -66,7 +66,7 @@ function compute_fixed_point{TV}(T::Function, v::TV; err_tol=1e-3,
     if iterate < max_iter && verbose
         println("Converged in $iterate steps")
     elseif iterate == max_iter
-        warn("max_iter exceeded in compute_fixed_point")
+        warn("max_iter attained in compute_fixed_point")
     end
 
     return v


### PR DESCRIPTION
If we look in [this notebook](http://nbviewer.jupyter.org/github/QuantEcon/QuantEcon.applications/blob/master/optgrowth/optgrowth_solutions_jl.ipynb) we see the warning

```
WARNING: max_iter exceeded in compute_fixed_point
```
It's a bit out of place because we deliberately set `max_iter`.  I can't think of a good fix so I just changed `exceeded` to `attained`.  