### PR TITLE
edited warnings

### DIFF
--- a/src/compute_fp.jl
+++ b/src/compute_fp.jl
@@ -73,14 +73,11 @@ function compute_fixed_point{TV}(T::Function,
         v = new_v
     end
 
-    if verbose == 1 && iterate == max_iter
-        warn("max_iter attained in compute_fixed_point")
-    end
-    if verbose == 2
-        if iterate < max_iter && verbose == 2
-            println("Converged in $iterate steps")
-        elseif iterate == max_iter
+    if verbose >= 1
+        if iterate == max_iter
             warn("max_iter attained in compute_fixed_point")
+        elseif verbose == 2
+            println("Converged in $iterate steps")
         end
     end
 


### PR DESCRIPTION
Example:

```
julia> f(x) = 0.5 * x
WARNING: Method definition f(Any) in module Main at REPL[14]:1 overwritten at REPL[22]:1.
f (generic function with 1 method)

julia> compute_fixed_point(f, 1.0, verbose=0)
6.103515625e-5

julia> compute_fixed_point(f, 1.0, verbose=1)
6.103515625e-5

julia> compute_fixed_point(f, 1.0, verbose=2)
Compute iterate 10 with error 0.0009765625
Converged in 14 steps
6.103515625e-5

julia> compute_fixed_point(f, 1.0, verbose=1, max_iter=5)
WARNING: max_iter attained in compute_fixed_point
0.03125

julia> compute_fixed_point(f, 1.0, verbose=0, max_iter=5)
0.03125

julia> compute_fixed_point(f, 1.0, verbose=10)
ERROR: ArgumentError: verbose should be 0, 1 or 2
 in #compute_fixed_point#3(::Float64, ::Int64, ::Int64, ::Int64, ::Function, ::#f, ::Float64) at /home/john/sync_dir/quantecon/QuantEcon.jl/src/compute_fp.jl:59
 in (::#kw##compute_fixed_point)(::Array{Any,1}, ::#compute_fixed_point, ::Function, ::Float64) at ./<missing>:0
```