### PR TITLE
ENH: added iterators for MarkovChain simulation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: julia
 sudo: false
 julia:
-    - 0.4
     - 0.5
     - nightly
 matrix:
@@ -10,9 +9,6 @@ matrix:
 notifications:
     email: false
 #script: # use the default script setting which is equivalent to the following
-#    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#    - julia -e 'Pkg.clone(pwd()); Pkg.build("QuantEcon")'
-#    - julia -e 'Pkg.test("QuantEcon", coverage=true)'
 after_success:
     - echo $TRAVIS_JULIA_VERSION
     - julia -e 'Pkg.add("Coverage"); cd(Pkg.dir("QuantEcon")); using Coverage; Coveralls.submit(process_folder()); Codecov.submit(process_folder())'

--- a/src/QuantEcon.jl
+++ b/src/QuantEcon.jl
@@ -42,7 +42,7 @@ export
     draw,
 
 # mc_tools
-    MarkovChain,
+    MarkovChain, MCIndSimulator, MCSimulator,
     stationary_distributions,
     simulate, simulate!, simulate_indices, simulate_indices!,
     period, is_irreducible, is_aperiodic, recurrent_classes,

--- a/src/markov/mc_tools.jl
+++ b/src/markov/mc_tools.jl
@@ -59,6 +59,8 @@ end
 MarkovChain(p::AbstractMatrix, state_values=1:size(p, 1)) =
     MarkovChain{eltype(p), typeof(p), typeof(state_values)}(p, state_values)
 
+Base.eltype{T,TM,TV}(mc::MarkovChain{T,TM,TV}) = eltype(TV)
+
 "Number of states in the Markov chain `mc`"
 n_states(mc::MarkovChain) = size(mc.p, 1)
 
@@ -290,6 +292,56 @@ end
 todense(::Type, A::Array) = A
 
 
+type MCIndSimulator{T<:MarkovChain,S}
+    mc::T
+    len::Int
+    init::Int
+    drvs::S
+end
+
+function MCIndSimulator(mc::MarkovChain, len::Int, init::Int)
+    # NOTE: ensure dense array and transpose before slicing the array. Then
+    #       when passing to DiscreteRV use `sub` to avoid allocating again
+    p = full(mc.p)'
+    drvs = [DiscreteRV(view(p, :, i)) for i in 1:size(mc.p, 1)]
+    MCIndSimulator(mc, len, init, drvs)
+end
+
+
+Base.start(mcis::MCIndSimulator) = (mcis.init, 0)
+
+function Base.next(mcis::MCIndSimulator, state::Tuple{Int,Int})
+    ix, t = state
+    (ix, (draw(mcis.drvs[ix]), t+1))
+end
+
+Base.done(mcis::MCIndSimulator, s::Tuple{Int,Int}) = s[2] >= mcis.len
+Base.length(mcis::MCIndSimulator) = mcis.len
+Base.iteratorsize(mcis::MCIndSimulator) = Base.HasLength()
+Base.eltype(mcis::MCIndSimulator) = Int
+
+type MCSimulator{T<:MCIndSimulator}
+    mcis::T
+end
+
+function MCSimulator(mc::MarkovChain, len::Int, init::Int)
+    MCSimulator(MCIndSimulator(mc, len, init))
+end
+
+# only need to implement next and eltype differently...
+function Base.next(mcs::MCSimulator, state::Tuple{Int,Int})
+    ix, new_state = next(mcs.mcis, state)
+    (mcs.mcis.mc.state_values[ix], new_state)
+end
+Base.eltype(mcs::MCSimulator) = eltype(mcs.mcis.mc)
+
+# ...the rest of the interface can derive from mcis
+Base.start(mcs::MCSimulator) = start(mcs.mcis)
+Base.done(mcs::MCSimulator, state::Tuple{Int,Int}) = done(mcs.mcis, state)
+Base.length(mcs::MCSimulator) = length(mcs.mcis)
+Base.iteratorsize(mcs::MCSimulator) = Base.iteratorsize(mcs.mcis)
+
+
 """
 Simulate one sample path of the Markov chain `mc`.
 The resulting vector has the state values of `mc` as elements.
@@ -298,17 +350,16 @@ The resulting vector has the state values of `mc` as elements.
 
 - `mc::MarkovChain` : MarkovChain instance.
 - `ts_length::Int` : Length of simulation
-- `;init::Int=rand(1:n_states(mc))` : Initial state 
+- `;init::Int=rand(1:n_states(mc))` : Initial state
 
 ### Returns
 
-- `X::Vector` : Vector containing the sample path, with length 
+- `X::Vector` : Vector containing the sample path, with length
 ts_length
 """
-
 function simulate(mc::MarkovChain, ts_length::Int;
                   init::Int=rand(1:n_states(mc)))
-    X = Array(eltype(mc.state_values), ts_length, 1)
+    X = Array(eltype(mc), ts_length, 1)
     simulate!(X, mc; init=init)
     return vec(X)
 end
@@ -321,54 +372,28 @@ The resulting matrix has the state values of `mc` as elements.
 ### Arguments
 
 - `X::Matrix` : Preallocated matrix to be filled with sample paths
-of the Markov chain `mc`. The element types in `X` should be the 
+of the Markov chain `mc`. The element types in `X` should be the
 same as the type of the state values of `mc`
 - `mc::MarkovChain` : MarkovChain instance.
 - `;init=rand(1:n_states(mc))` : Can be one of the following
     - blank: random initial condition for each chain
     - scalar: same initial condition for each chain
     - vector: cycle through the elements, applying each as an
-      initial condition until all columns have an initial condition 
+      initial condition until all columns have an initial condition
       (allows for more columns than initial conditions)
 """
 
 function simulate!(X::Union{AbstractVector,AbstractMatrix},
                    mc::MarkovChain; init=rand(1:n_states(mc), size(X, 2)))
+    mcs = MCSimulator(mc, size(X, 1), init[1])
 
-    # Note: eltype(X) must be the same as eltype(mc.state_values)
-    if eltype(X) != eltype(mc.state_values)
-        throw(ArgumentError("Types in X must be the same as the types of the
-        Markov state values"))
-    end
-
-    ts_length = size(X, 1)
-    k = size(X, 2)
-    
-    # if init is a vector, assign initial conditions to columns of X
-    # otherwise, just start each column at the same initial condition
-    if length(init) > 1
-        real_init = collect(take(cycle(init), k))
-    else
-        real_init = init .* ones(Int, k)
-    end
-    X[1, :] = mc.state_values[real_init]
-
-    n = size(mc.p, 1)
-
-    # NOTE: ensure dense array and transpose before slicing the array. Then
-    #       when passing to DiscreteRV use `sub` to avoid allocating again
-    p = full(mc.p)'
-    P_dist = [DiscreteRV(view(p, :, i)) for i in 1:n]
-
-    for i in 1:k
-        i_state = real_init[i]
-        for t in 1:ts_length-1
-            i_state = draw(P_dist[i_state])
-            X[t+1, i] = mc.state_values[i_state]
+    for (i, init) in enumerate(take(cycle(init), size(X, 2)))
+        mcs.mcis.init = init
+        for (t, item) in enumerate(mcs)
+            X[t, i] = item
         end
     end
     X
-
 end
 
 # ------------------------ #
@@ -383,14 +408,13 @@ The resulting vector has the indices of the state values of `mc` as elements.
 
 - `mc::MarkovChain` : MarkovChain instance.
 - `ts_length::Int` : Length of simulation
-- `;init::Int=rand(1:n_states(mc))` : Initial state 
+- `;init::Int=rand(1:n_states(mc))` : Initial state
 
 ### Returns
 
-- `X::Vector{Int}` : Vector containing the sample path, with length 
+- `X::Vector{Int}` : Vector containing the sample path, with length
 ts_length
 """
-
 function simulate_indices(mc::MarkovChain, ts_length::Int;
                           init::Int=rand(1:n_states(mc)))
     X = Array(Int, ts_length, 1)
@@ -412,37 +436,18 @@ of the sample paths of the Markov chain `mc`.
     - blank: random initial condition for each chain
     - scalar: same initial condition for each chain
     - vector: cycle through the elements, applying each as an
-      initial condition until all columns have an initial condition 
+      initial condition until all columns have an initial condition
       (allows for more columns than initial conditions)
 """
-
 function simulate_indices!{T<:Integer}(X::Union{AbstractVector{T},AbstractMatrix{T}},
                            mc::MarkovChain; init=rand(1:n_states(mc), size(X, 2)))
+    mcis = MCIndSimulator(mc, size(X, 1), init[1])
 
-    ts_length = size(X, 1)
-    k = size(X, 2)
-   
-    # if init is a vector, assign initial conditions to columns of X
-    # otherwise, just start each column at the same initial condition
-    if length(init) > 1
-        real_init = collect(take(cycle(init), k))
-    else
-        real_init = init .* ones(Int, k)
-    end
-    X[1, :] = real_init
-
-    n = size(mc.p, 1)
-
-    # NOTE: ensure dense array and transpose before slicing the array. Then
-    #       when passing to DiscreteRV use `sub` to avoid allocating again
-    p = full(mc.p)'
-    P_dist = [DiscreteRV(view(p, :, i)) for i in 1:n]
-
-    for i in 1:k
-        for t in 1:ts_length-1
-            X[t+1, i] = draw(P_dist[X[t,i]])
+    for (i, init) in enumerate(take(cycle(init), size(X, 2)))
+        mcis.init = init
+        for (t, item) in enumerate(mcis)
+            X[t, i] = item
         end
     end
     X
-
 end

--- a/src/markov/mc_tools.jl
+++ b/src/markov/mc_tools.jl
@@ -359,9 +359,8 @@ ts_length
 """
 function simulate(mc::MarkovChain, ts_length::Int;
                   init::Int=rand(1:n_states(mc)))
-    X = Array(eltype(mc), ts_length, 1)
+    X = Array(eltype(mc), ts_length)
     simulate!(X, mc; init=init)
-    return vec(X)
 end
 
 
@@ -389,9 +388,7 @@ function simulate!(X::Union{AbstractVector,AbstractMatrix},
 
     for (i, init) in enumerate(take(cycle(init), size(X, 2)))
         mcs.mcis.init = init
-        for (t, item) in enumerate(mcs)
-            X[t, i] = item
-        end
+        copy!(view(X, :, i), mcs)
     end
     X
 end
@@ -417,9 +414,8 @@ ts_length
 """
 function simulate_indices(mc::MarkovChain, ts_length::Int;
                           init::Int=rand(1:n_states(mc)))
-    X = Array(Int, ts_length, 1)
+    X = Array(Int, ts_length)
     simulate_indices!(X, mc; init=init)
-    return vec(X)
 end
 
 
@@ -445,9 +441,7 @@ function simulate_indices!{T<:Integer}(X::Union{AbstractVector{T},AbstractMatrix
 
     for (i, init) in enumerate(take(cycle(init), size(X, 2)))
         mcis.init = init
-        for (t, item) in enumerate(mcis)
-            X[t, i] = item
-        end
+        copy!(view(X, :, i), mcis)
     end
     X
 end

--- a/test/test_mc_tools.jl
+++ b/test/test_mc_tools.jl
@@ -403,9 +403,9 @@ end
                        (ts_length, )
             for num_sims in nums_sims
                 X = Array(Int64, ts_length, num_sims)
-                @test size(simulate_indices!(X, mc)) == 
+                @test size(simulate_indices!(X, mc)) ==
                            (ts_length, num_sims)
-                @test size(simulate_indices!(X, mc; init=init)) == 
+                @test size(simulate_indices!(X, mc; init=init)) ==
                            (ts_length, num_sims)
             end
         end
@@ -467,9 +467,9 @@ end
                 @test size(@inferred(simulate(mc, ts_length))) == (ts_length,)
                 for num_sims in nums_sims
                     X = Array(T, ts_length, num_sims)
-                    @test size(simulate!(X, mc)) == 
+                    @test size(simulate!(X, mc)) ==
                            (ts_length, num_sims)
-                    @test size(simulate!(X, mc; init=init)) == 
+                    @test size(simulate!(X, mc; init=init)) ==
                            (ts_length, num_sims)
                 end
             end  # state_values eltypes
@@ -492,6 +492,51 @@ end
                 @test vec(X[1, :]) == mc.state_values[collect(take(cycle(init), num_sims))]
             end
         end  # testset
+    end
+
+    @testset "simulate iterators" begin
+        p = [0.0 1.0 0.0 0.0
+             0.0 0.0 1.0 0.0
+             0.0 0.0 0.0 1.0
+             1.0 0.0 0.0 0.0]
+        mc = MarkovChain(p, [10.0, 20.0, 30.0, 40.0])
+
+        mcis = MCIndSimulator(mc, 50, 1)
+
+        want = collect(take(cycle(1:4), 50))
+        have = Array(Int, 50)
+        for (ix, i) in enumerate(mcis)
+            have[ix] = i
+        end
+        @test have == want
+
+        @test start(mcis) == (1, 0)
+        for i in 1:49
+            @test !done(mcis, (1, i))
+        end
+        @test done(mcis, (1, 50))
+        @test length(mcis) == 50
+        @test Base.iteratorsize(mcis) == Base.HasLength()
+        @test eltype(mcis) == Int
+
+        mcs = MCSimulator(mc, 50, 1)
+        want = collect(take(cycle([10, 20, 30, 40]), 50))
+        have = zeros(Float64, 50)
+        for (ix, i) in enumerate(mcs)
+            have[ix] = i
+        end
+
+        @test have == want
+
+        @test start(mcs) == (1, 0)
+        for i in 1:49
+            @test !done(mcs, (1, i))
+        end
+        @test done(mcs, (1, 50))
+        @test length(mcs) == 50
+        @test Base.iteratorsize(mcs) == Base.HasLength()
+        @test eltype(mcs) == Float64
+
     end
 
 end  # testset


### PR DESCRIPTION
This PR revamps the internals behind `simulate` and `simulate_indices` to use the Julia iterator protocol.

The current API for `simulate`, `simulate!`, `simulate_indices`, `simulate_indices!` has not changed. 

However, we can now do things more flexibly.  I have defined two new types `MCIndSimulator` and `MCSimulator` that are responsible for _iterating_ over the simulation of a MarkovChain. This enables us to do things like

```julia
mcs = MCSimulator(mc, 200, 1)

# get multiple simulations, using same initial condition
sim1 = collect(mcs)
sim2 = collect(mcs)

# iterate over a simulation path, without creating array to hold path
for i in mcs
    do_something_cool(i)
end
```

You can see the new (and greatly simplified!!) implementation of `simulate!` and `simulate_indices!` for other ideas about what is possible.