### PR TITLE
Sl/0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ sudo: false
 julia:
     - 0.5
     - nightly
-matrix:
-  allow_failures:
-    - julia: nightly
 notifications:
     email: false
 #script: # use the default script setting which is equivalent to the following

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: julia
 sudo: false
 julia:
-    - 0.4
     - 0.5
     - nightly
 matrix:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.5
 DSP
 Distributions 0.8.9
 LightGraphs

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,5 +3,5 @@ DSP
 Distributions 0.8.9
 LightGraphs
 Primes
-Compat 0.8.4
+Compat 0.18.0
 StatsBase

--- a/docs/src/api/QuantEcon.md
+++ b/docs/src/api/QuantEcon.md
@@ -13,6 +13,12 @@ API documentation
 Pages = ["QuantEcon.md"]
 ```
 
+## Index
+
+```@index
+Pages = ["QuantEcon.md"]
+```
+
 ## Exported
 
 ```@autodocs
@@ -25,10 +31,4 @@ Private = false
 ```@autodocs
 Modules = [QuantEcon]
 Public = false
-```
-
-## Index
-
-```@index
-Pages = ["QuantEcon.md"]
 ```

--- a/src/QuantEcon.jl
+++ b/src/QuantEcon.jl
@@ -11,6 +11,10 @@ using DSP: TFFilter, freqz
 using Primes: primes
 using Compat: view, @compat
 
+@static if isdefined(Base, :Iterators)
+    using Base.Iterators: cycle, take
+end
+
 # useful types
 typealias ScalarOrArray{T} Union{T, Array{T}}
 

--- a/src/QuantEcon.jl
+++ b/src/QuantEcon.jl
@@ -16,7 +16,7 @@ using Compat: view, @compat
 end
 
 # useful types
-typealias ScalarOrArray{T} Union{T, Array{T}}
+@compat ScalarOrArray{T} = Union{T,Array{T}}
 
 
 export

--- a/src/arma.jl
+++ b/src/arma.jl
@@ -119,7 +119,7 @@ function spectral_density(arma::ARMA; res=1200, two_pi::Bool=true)
     w = linspace(0, wmax, res)
     tf = TFFilter(reverse(arma.ma_poly), reverse(arma.ar_poly))
     h = freqz(tf, w)
-    spect = arma.sigma^2 * abs(h).^2
+    spect = arma.sigma.^2 .* abs.(h).^2
     return w, spect
 end
 
@@ -166,7 +166,7 @@ function impulse_response(arma::ARMA; impulse_length=30)
     # == Pad theta with zeros at the end == #
     theta = [arma.theta; zeros(impulse_length - arma.q)]
     psi_zero = 1.0
-    psi = Array(Float64, impulse_length)
+    psi = Array{Float64}(impulse_length)
     for j = 1:impulse_length
         psi[j] = theta[j]
         for i = 1:min(j, arma.p)
@@ -197,7 +197,7 @@ function simulation(arma::ARMA; ts_length=90, impulse_length=30)
     T = ts_length
     psi = impulse_response(arma, impulse_length=impulse_length)
     epsilon = arma.sigma * randn(T + J)
-    X = Array(Float64, T)
+    X = Array{Float64}(T)
     for t=1:T
         X[t] = dot(epsilon[t:J+t-1], psi)
     end

--- a/src/compute_fp.jl
+++ b/src/compute_fp.jl
@@ -64,7 +64,7 @@ function compute_fixed_point{TV}(T::Function,
     while iterate < max_iter && err > err_tol
         new_v = T(v)::TV
         iterate += 1
-        err = Base.maxabs(new_v - v)
+        err = Base.maximum(abs, new_v - v)
         if verbose == 2
             if iterate % print_skip == 0
                 println("Compute iterate $iterate with error $err")

--- a/src/discrete_rv.jl
+++ b/src/discrete_rv.jl
@@ -31,7 +31,7 @@ vector of probabilities given by q.
 type DiscreteRV{TV1<:AbstractVector, TV2<:AbstractVector}
     q::TV1
     Q::TV2
-    @compat function (::Type{DiscreteRV{TV1,TV2}}){TV1,TV2}(q, Q)
+    function (::Type{DiscreteRV{TV1,TV2}}){TV1,TV2}(q, Q)
         abs(Q[end] - 1) > 1e-10 && error("q should sum to 1")
         new{TV1,TV2}(q, Q)
     end

--- a/src/discrete_rv.jl
+++ b/src/discrete_rv.jl
@@ -31,9 +31,9 @@ vector of probabilities given by q.
 type DiscreteRV{TV1<:AbstractVector, TV2<:AbstractVector}
     q::TV1
     Q::TV2
-    function DiscreteRV(q, Q)
+    @compat function (::Type{DiscreteRV{TV1,TV2}}){TV1,TV2}(q, Q)
         abs(Q[end] - 1) > 1e-10 && error("q should sum to 1")
-        new(q, Q)
+        new{TV1,TV2}(q, Q)
     end
 end
 

--- a/src/ecdf.jl
+++ b/src/ecdf.jl
@@ -21,15 +21,14 @@ type ECDF
     observations::Vector
 end
 
-ecdf(e::ECDF, x::Real) = mean(e.observations .<= x)
-ecdf(e::ECDF, x::Array) = map(i->ecdf(e, i), x)
-
 """
 Evaluate the empirical cdf at one or more points
 
 ##### Arguments
 
-- `e::ECDF`: The `ECDF` instance
 - `x::Union{Real, Array}`: The point(s) at which to evaluate the ECDF
 """
-ecdf
+(e::ECDF)(x::Real) = mean(e.observations .<= x)
+(e::ECDF)(x::AbstractArray) = e.(x)
+
+@deprecate ecdf(e::ECDF, x) e(x)

--- a/src/estspec.jl
+++ b/src/estspec.jl
@@ -49,7 +49,7 @@ function smooth(x::Array, window_len::Int, window::AbstractString="hanning")
                    )
 
     # Reflect x around x[0] and x[-1] prior to convolution
-    k = round(Int, window_len / 2)
+    k = ceil(Int, window_len / 2)
     xb = x[1:k]   # First k elements
     xt = x[end-k+1:end]  # Last k elements
     s = [reverse(xb); x; reverse(xt)]

--- a/src/estspec.jl
+++ b/src/estspec.jl
@@ -73,7 +73,7 @@ end
 
 function periodogram(x::Vector)
     n = length(x)
-    I_w = abs(fft(x)).^2 ./ n
+    I_w = abs.(fft(x)).^2 ./ n
     w = 2pi * (0:n-1) ./ n  # Fourier frequencies
 
     # int rounds to nearest integer. We want to round up or take 1/2 + 1 to
@@ -148,7 +148,7 @@ function ar_periodogram(x::Array, window::AbstractString="hanning", window_len::
     w, I_w = periodogram(e_hat, window, window_len)
 
     # recolor and return
-    I_w = I_w ./ abs(1 - phi .* exp(im.*w)).^2
+    I_w = I_w ./ abs.(1 .- phi .* exp.(im.*w)).^2
 
     return w, I_w
 end

--- a/src/interp.jl
+++ b/src/interp.jl
@@ -28,7 +28,7 @@ immutable LinInterp{TB<:AbstractVector,TV<:AbstractVector}
     vals::TV
     _n::Int
 
-    function LinInterp(b, v)
+    @compat function (::Type{LinInterp{TB,TV}}){TB,TV}(b::TB, v::TV)
         if size(b, 1) != size(v, 1)
             m = "breaks and vals must have same number of elements"
             throw(DimensionMismatch(m))
@@ -38,7 +38,7 @@ immutable LinInterp{TB<:AbstractVector,TV<:AbstractVector}
             m = "breaks must be sorted"
             throw(ArgumentError(m))
         end
-        new(b, v, length(b))
+        new{TB,TV}(b, v, length(b))
     end
 end
 

--- a/src/interp.jl
+++ b/src/interp.jl
@@ -28,7 +28,7 @@ immutable LinInterp{TB<:AbstractVector,TV<:AbstractVector}
     vals::TV
     _n::Int
 
-    @compat function (::Type{LinInterp{TB,TV}}){TB,TV}(b::TB, v::TV)
+    function (::Type{LinInterp{TB,TV}}){TB,TV}(b::TB, v::TV)
         if size(b, 1) != size(v, 1)
             m = "breaks and vals must have same number of elements"
             throw(DimensionMismatch(m))

--- a/src/lqcontrol.jl
+++ b/src/lqcontrol.jl
@@ -95,14 +95,14 @@ symmetric and nonnegative definite
 Must be symmetric and nonnegative definite
 - `A::ScalarOrArray` : n x n coefficient on state in state transition
 - `B::ScalarOrArray` : n x k coefficient on control in state transition
-- `;C::ScalarOrArray(zeros(size(R, 1)))` : n x j coefficient on random shock in
+- `;C::ScalarOrArray{zeros(size(R}(1)))` : n x j coefficient on random shock in
 state transition
-- `;N::ScalarOrArray(zeros(size(B,1), size(A, 2)))` : k x n cross product in
+- `;N::ScalarOrArray{zeros(size(B,1)}(size(A, 2)))` : k x n cross product in
 payoff equation
 - `;bet::Real(1.0)` : Discount factor in [0, 1]
 - `capT::Union{Int, Void}(Void)` : Terminal period in finite horizon
 problem
-- `rf::ScalarOrArray(fill(NaN, size(R)...))` : n x n terminal payoff in finite
+- `rf::ScalarOrArray{fill(NaN}(size(R)...))` : n x n terminal payoff in finite
 horizon problem. Must be symmetric and nonnegative definite.
 
 """
@@ -232,8 +232,8 @@ Private method implementing `compute_sequence` when state is a scalar
 function _compute_sequence{T}(lq::LQ, x0::T, policies)
     capT = length(policies)
 
-    x_path = Array(T, capT+1)
-    u_path = Array(T, capT)
+    x_path = Array{T}(capT+1)
+    u_path = Array{T}(capT)
 
     x_path[1] = x0
     u_path[1] = -(first(policies)*x0)
@@ -259,8 +259,8 @@ function _compute_sequence{T}(lq::LQ, x0::Vector{T}, policies)
 
     A, B, C = lq.A, reshape(lq.B, n, k), reshape(lq.C, n, j)
 
-    x_path = Array(T, n, capT+1)
-    u_path = Array(T, k, capT)
+    x_path = Array{T}(n, capT+1)
+    u_path = Array{T}(k, capT)
     w_path = C*randn(j, capT+1)
 
     x_path[:, 1] = x0
@@ -305,7 +305,7 @@ function compute_sequence(lq::LQ, x0::ScalarOrArray, ts_length::Integer=100)
         policies = fill(lq.F, ts_length)
     else
         capT = min(ts_length, lq.capT)
-        policies = Array(typeof(lq.F), capT)
+        policies = Array{typeof(lq.F)}(capT)
         for t = capT:-1:1
             update_values!(lq)
             policies[t] = lq.F

--- a/src/lqnash.jl
+++ b/src/lqnash.jl
@@ -100,7 +100,7 @@ function nnash(a, b1, b2, r1, r2, q1, q2, s1, s2, w1, w2, m1, m2;
         p1 = (a2'*p1*a2) .+ r1 .+ (f2'*s1*f2) .- (a2'*p1*b1 .+ w1 .- f2'*m1)*f1
         p2 = (a1'*p2*a1) .+ r2 .+ (f1'*s2*f1) .- (a1'*p2*b2 .+ w2 .- f1'*m2)*f2
 
-        dd = maximum(abs(f10 .- f1) + abs(f20 .- f2))
+        dd = maximum(abs.(f10 .- f1) + abs.(f20 .- f2))
         its = its + 1
         if its > max_iter
             error("Reached max iterations, no convergence")

--- a/src/lss.jl
+++ b/src/lss.jl
@@ -158,7 +158,7 @@ immutable LSSMoments
 end
 
 Base.start(L::LSSMoments) = (copy(L.lss.mu_0), copy(L.lss.Sigma_0))
-Base.done(L::LSSMoments, _) = false
+Base.done(L::LSSMoments, x) = false
 function Base.next(L::LSSMoments, moms)
     A, C, G = L.lss.A, L.lss.C, L.lss.G
     mu_x, Sigma_x = moms

--- a/src/lss.jl
+++ b/src/lss.jl
@@ -111,7 +111,7 @@ end
 
 
 function simulate(lss::LSS, ts_length=100)
-    x = Array(Float64, lss.n, ts_length)
+    x = Array{Float64}(lss.n, ts_length)
     x[:, 1] = rand(lss.dist)
     w = randn(lss.m, ts_length - 1)
     for t=1:ts_length-1
@@ -140,7 +140,7 @@ Simulate num_reps observations of x_T and y_T given x_0 ~ N(mu_0, Sigma_0).
 
 """
 function replicate(lss::LSS, t::Integer, num_reps::Integer=100)
-    x = Array(Float64, lss.n, num_reps)
+    x = Array{Float64}(lss.n, num_reps)
     for j=1:num_reps
         x_t, _ = simulate(lss, t+1)
         x[:, j] = x_t[:, end]

--- a/src/markov/ddp.jl
+++ b/src/markov/ddp.jl
@@ -53,7 +53,7 @@ type DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind}
     a_indices::Nullable{Vector{Tind}}  # Action Indices
     a_indptr::Nullable{Vector{Tind}}   # Action Index Pointers
 
-    @compat function (::Type{DiscreteDP{T,NQ,NR,Tbeta,Tind}}){T,NQ,NR,Tbeta,Tind}(
+    function (::Type{DiscreteDP{T,NQ,NR,Tbeta,Tind}}){T,NQ,NR,Tbeta,Tind}(
             R::Array, Q::Array, beta::Real
         )
         # verify input integrity 1
@@ -92,7 +92,7 @@ type DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind}
     # Note: We left R, Q as type Array to produce more helpful error message with regards to shape.
     # R and Q are dense Arrays
 
-    @compat function (::Type{DiscreteDP{T,NQ,NR,Tbeta,Tind}}){T,NQ,NR,Tbeta,Tind}(
+    function (::Type{DiscreteDP{T,NQ,NR,Tbeta,Tind}}){T,NQ,NR,Tbeta,Tind}(
             R::AbstractArray, Q::AbstractArray, beta::Real, s_indices::Vector,
             a_indices::Vector
         )
@@ -269,7 +269,7 @@ type DPSolveResult{Algo<:DDPAlgorithm,Tval<:Real}
     sigma::Array{Int,1}
     mc::MarkovChain
 
-    @compat function (::Type{DPSolveResult{Algo,Tval}}){Algo,Tval}(
+    function (::Type{DPSolveResult{Algo,Tval}}){Algo,Tval}(
             ddp::DiscreteDP
         )
         v = s_wise_max(ddp, ddp.R) # Initialise v with v_init
@@ -281,7 +281,7 @@ type DPSolveResult{Algo<:DDPAlgorithm,Tval<:Real}
     end
 
     # method to pass initial value function (skip the s-wise max)
-    @compat function (::Type{DPSolveResult{Algo,Tval}}){Algo,Tval}(
+    function (::Type{DPSolveResult{Algo,Tval}}){Algo,Tval}(
             ddp::DiscreteDP, v::Vector
         )
         ddpr = new{Algo,Tval}(v, similar(v), 0, similar(v, Int))

--- a/src/markov/ddp.jl
+++ b/src/markov/ddp.jl
@@ -115,7 +115,7 @@ type DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind}
         end
 
         if _has_sorted_sa_indices(s_indices, a_indices)
-            a_indptr = Array(Int64, num_states+1)
+            a_indptr = Array{Int64}(num_states+1)
             _a_indices = copy(a_indices)
             _generate_a_indptr!(num_states, s_indices, a_indptr)
         else
@@ -539,7 +539,7 @@ end
 
 # TODO: express it in a similar way as above to exploit Julia's column major order
 function RQ_sigma{T<:Integer}(ddp::DDPsa, sigma::Array{T})
-    sigma_indices = Array(T, num_states(ddp))
+    sigma_indices = Array{T}(num_states(ddp))
     _find_indices!(get(ddp.a_indices), get(ddp.a_indptr), sigma, sigma_indices)
     R_sigma = ddp.R[sigma_indices]
     Q_sigma = ddp.Q[sigma_indices, :]
@@ -602,7 +602,7 @@ end
 
 function s_wise_max(ddp::DDPsa, vals::Vector)
     s_wise_max!(get(ddp.a_indices), get(ddp.a_indptr), vals,
-                 Array(Float64, num_states(ddp)))
+                 Array{Float64}(num_states(ddp)))
 end
 
 s_wise_max!(ddp::DDPsa, vals::Vector, out::Vector, out_argmax::Vector) =
@@ -751,7 +751,7 @@ function _solve!(ddp::DiscreteDP, ddpr::DPSolveResult{VFI}, max_iter::Integer,
         bellman_operator!(ddp, ddpr)
 
         # compute error and update the v inside ddpr
-        err = maxabs(ddpr.Tv .- ddpr.v)
+        err = maximum(abs, ddpr.Tv .- ddpr.v)
         copy!(ddpr.v, ddpr.Tv)
         ddpr.num_iter += 1
 

--- a/src/markov/mc_tools.jl
+++ b/src/markov/mc_tools.jl
@@ -33,7 +33,7 @@ type MarkovChain{T, TM<:AbstractMatrix, TV<:AbstractVector}
     p::TM # valid stochastic matrix
     state_values::TV
 
-    function MarkovChain(p::AbstractMatrix, state_values)
+    @compat function (::Type{MarkovChain{T,TM,TV}}){T,TM,TV}(p::AbstractMatrix, state_values)
         n, m = size(p)
 
         eltype(p) != T &&
@@ -51,7 +51,7 @@ type MarkovChain{T, TM<:AbstractMatrix, TV<:AbstractVector}
         length(state_values) != n &&
             throw(DimensionMismatch("state_values should have $n elements"))
 
-        return new(p, state_values)
+        return new{T,TM,TV}(p, state_values)
     end
 end
 

--- a/src/markov/mc_tools.jl
+++ b/src/markov/mc_tools.jl
@@ -13,7 +13,7 @@ http://quant-econ.net/jl/finite_markov.html
 import LightGraphs: DiGraph, period, attracting_components,
                     strongly_connected_components, is_strongly_connected
 
-@inline check_stochastic_matrix(P) = maxabs(sum(P, 2) - 1) < 1e-15 ? true : false
+@inline check_stochastic_matrix(P) = maximum(abs, sum(P, 2) - 1) < 1e-15 ? true : false
 
 """
 Finite-state discrete-time Markov chain.
@@ -240,7 +240,7 @@ for (S, ex_T, ex_gth) in ((Real, :(T), :(gth_solve!)),
         n = n_states(mc)
         rec_classes = recurrent_classes(mc)
         T1 = $ex_T
-        stationary_dists = Array(Vector{T1}, length(rec_classes))
+        stationary_dists = Array{Vector{T1}}(length(rec_classes))
 
         for (i, rec_class) in enumerate(rec_classes)
             dist = zeros(T1, n)
@@ -361,7 +361,7 @@ ts_length
 """
 function simulate(mc::MarkovChain, ts_length::Int;
                   init::Int=rand(1:n_states(mc)))
-    X = Array(eltype(mc), ts_length)
+    X = Array{eltype(mc)}(ts_length)
     simulate!(X, mc; init=init)
 end
 
@@ -416,7 +416,7 @@ ts_length
 """
 function simulate_indices(mc::MarkovChain, ts_length::Int;
                           init::Int=rand(1:n_states(mc)))
-    X = Array(Int, ts_length)
+    X = Array{Int}(ts_length)
     simulate_indices!(X, mc; init=init)
 end
 

--- a/src/markov/mc_tools.jl
+++ b/src/markov/mc_tools.jl
@@ -33,7 +33,7 @@ type MarkovChain{T, TM<:AbstractMatrix, TV<:AbstractVector}
     p::TM # valid stochastic matrix
     state_values::TV
 
-    @compat function (::Type{MarkovChain{T,TM,TV}}){T,TM,TV}(p::AbstractMatrix, state_values)
+    function (::Type{MarkovChain{T,TM,TV}}){T,TM,TV}(p::AbstractMatrix, state_values)
         n, m = size(p)
 
         eltype(p) != T &&

--- a/src/markov/random_mc.jl
+++ b/src/markov/random_mc.jl
@@ -215,7 +215,7 @@ function random_probvec(k::Integer, m::Integer)
     k == 1 && return ones((k, m))
 
     # if k >= 2
-    x = Array(Float64, (k, m))
+    x = Array{Float64}((k, m))
 
     r = rand(k-1, m)
     x[1:end-1, :] = sort(r, 1)

--- a/src/matrix_eqn.jl
+++ b/src/matrix_eqn.jl
@@ -46,7 +46,7 @@ function solve_discrete_lyapunov(A::ScalarOrArray,
         alpha1 = alpha0*alpha0
         gamma1 = gamma0 + alpha0*gamma0*alpha0'
 
-        diff = maximum(abs(gamma1 - gamma0))
+        diff = maximum(abs, gamma1 - gamma0)
         alpha0 = alpha1
         gamma0 = gamma1
 
@@ -159,7 +159,7 @@ function solve_discrete_riccati(A::ScalarOrArray, B::ScalarOrArray,
         G1 = G0 + A0 * G0 * ((I + H0 * G0)\A0')
         H1 = H0 + A0' * ((I + H0*G0)\(H0*A0))
 
-        dist = Base.maxabs(H1 - H0)
+        dist = Base.maximum(abs, H1 - H0)
         A0 = A1
         G0 = G1
         H0 = H1

--- a/src/optimization.jl
+++ b/src/optimization.jl
@@ -19,7 +19,7 @@ function golden_method(f::Function, a::AbstractVector, b::AbstractVector;
         f1[i] = f2[i]
         d *= α2
         x2 = x1 + s.*(i- ~i).*d
-        s = sign(x2 - x1)
+        s = sign.(x2 .- x1)
         f2 = f(x2)
     end
 

--- a/src/optimization.jl
+++ b/src/optimization.jl
@@ -18,7 +18,7 @@ function golden_method(f::Function, a::AbstractVector, b::AbstractVector;
         x1[i] = x2[i]
         f1[i] = f2[i]
         d *= α2
-        x2 = x1 + s.*(i- ~i).*d
+        x2 = x1 + s.*(i- map(!, i)).*d
         s = sign.(x2 .- x1)
         f2 = f(x2)
     end

--- a/src/quad.jl
+++ b/src/quad.jl
@@ -80,7 +80,7 @@ function qnwlege(n::Int, a::Real, b::Real)
         z1 = z
         z = z1 - p1./pp
 
-        err = Base.maxabs(z - z1)
+        err = Base.maximum(abs, z - z1)
         if err < 1e-14
             break
         end
@@ -535,8 +535,8 @@ function qnwnorm(n::Vector{Int}, mu::Vector, sig2::Matrix=eye(length(n)))
         error("n and mu must have same number of elements")
     end
 
-    _nodes = Array(Vector{Float64}, n_n)
-    _weights = Array(Vector{Float64}, n_n)
+    _nodes = Array{Vector{Float64}}(n_n)
+    _weights = Array{Vector{Float64}}(n_n)
 
     for i in 1:n_n
         _nodes[i], _weights[i] = qnwnorm(n[i])
@@ -637,7 +637,7 @@ end
 
 
 ## qnwequi
-const equidist_pp = sqrt(primes(7920))  # good for d <= 1000
+const equidist_pp = sqrt.(primes(7920))  # good for d <= 1000
 
 
 """

--- a/src/quad.jl
+++ b/src/quad.jl
@@ -521,8 +521,8 @@ for f in [:qnwlege, :qnwcheb, :qnwsimp, :qnwtrap, :qnwbeta, :qnwgamma]
                 push!(weights, _1d[2])
             end
             weights = ckron(weights[end:-1:1]...)
-            nodes = gridmake(nodes...)
-            return nodes, weights
+            nodes_out = gridmake(nodes...)::Matrix{Float64}
+            return nodes_out, weights
         end
     end  # @eval
 end
@@ -543,11 +543,12 @@ function qnwnorm(n::Vector{Int}, mu::Vector, sig2::Matrix=eye(length(n)))
     end
 
     weights = ckron(_weights[end:-1:1]...)
-    nodes = gridmake(_nodes...)
+    nodes = gridmake(_nodes...)::Matrix{Float64}
 
     new_sig2 = chol(sig2)
 
-    nodes = nodes * new_sig2 .+ mu'
+    A_mul_B!(nodes, nodes, new_sig2)
+    broadcast!(+, nodes, nodes, mu')
 
     return nodes, weights
 end

--- a/src/quad.jl
+++ b/src/quad.jl
@@ -60,7 +60,7 @@ function qnwlege(n::Int, a::Real, b::Real)
     weights = copy(nodes)
     i = 1:m
 
-    z = cos(pi * (i - 0.25) ./ (n + 0.5))
+    z = cos.(pi * (i - 0.25) ./ (n + 0.5))
 
     # allocate memory for loop arrays
     p3 = similar(z)
@@ -116,8 +116,8 @@ $(qnw_func_notes)
 $(qnw_refs)
 """
 function qnwcheb(n::Int, a::Real, b::Real)
-    nodes = (b+a)/2 - (b-a)/2 .* cos(pi/n .* (0.5:(n-0.5)))
-    weights = ((b-a)/n) .* (cos(pi/n .* ((1:n)-0.5)*(2:2:n-1)') *
+    nodes = (b+a)/2 - (b-a)/2 .* cos.(pi/n .* (0.5:(n-0.5)))
+    weights = ((b-a)/n) .* (cos.(pi/n .* ((1:n)-0.5)*(2:2:n-1)') *
                             (-2.0 ./ ((1:2:n-2).*(3:2:n))) + 1)
     return nodes, weights
 end
@@ -633,7 +633,7 @@ $(qnw_refs)
 """
 function qnwlogn(n, mu, sig2)
     nodes, weights = qnwnorm(n, mu, sig2)
-    return exp(nodes), weights
+    return exp.(nodes), weights
 end
 
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -79,6 +79,7 @@ end
 function gridmake{T}(arrays::AbstractVector{T}...)
     out = Array{T}(prod([length(a) for a in  arrays]), length(arrays))
     gridmake!(out, arrays...)
+    out
 end
 
 function gridmake(t::Tuple)

--- a/src/util.jl
+++ b/src/util.jl
@@ -68,10 +68,15 @@ function gridmake!(out, arrays::Union{AbstractVector,AbstractMatrix}...)
 end
 
 @generated function gridmake(arrays::AbstractArray...)
-    T = reduce(promote_type, [eltype(a) for a in arrays])
+    T = reduce(promote_type, eltype(a) for a in arrays)
     quote
-        l = prod(_ -> size(_, 1), arrays)
-        out = Array{$T}(l, sum(_ -> size(_, 2), arrays))
+        l = 1
+        n = 0
+        for arr in arrays
+            l *= size(arr, 1)
+            n += size(arr, 2)
+        end
+        out = Array{$T}(l, n)
         gridmake!(out, arrays...)
         out
     end

--- a/src/util.jl
+++ b/src/util.jl
@@ -40,7 +40,7 @@ Like `gridmake`, but fills a pre-populated array. `out` must have size
 function gridmake!(out, arrays::Union{AbstractVector,AbstractMatrix}...)
     lens = Int[size(e, 1) for e in arrays]
 
-    n = sum(_ -> size(_, 2), arrays)
+    n = sum(_i -> size(_i, 2), arrays)
     l = prod(lens)
     @assert size(out) == (l, n)
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -37,10 +37,10 @@ ckron
 Like `gridmake`, but fills a pre-populated array. `out` must have size
 `prod(map(length, arrays), length(arrays))`
 """
-function gridmake!(out, arrays::AbstractVector...)
-    lens = Int[length(e) for e in arrays]
+function gridmake!(out, arrays::Union{AbstractVector,AbstractMatrix}...)
+    lens = Int[size(e, 1) for e in arrays]
 
-    n = length(arrays)
+    n = sum(_ -> size(_, 2), arrays)
     l = prod(lens)
     @assert size(out) == (l, n)
 
@@ -49,39 +49,32 @@ function gridmake!(out, arrays::AbstractVector...)
     reverse!(repititions)
     reverse!(lens)  # put lens back in correct order
 
-    @inbounds for col=1:n
-        row = 1
-        arr = arrays[col]
-        outer = repititions[col]
-        inner = floor(Int, l / (outer * lens[col]))
-        for _ in 1:outer
-            for ix in 1:lens[col]
-                v = arr[ix]
-                for _ in 1:inner
-                    out[row, col] = v
-                    row += 1
-                end
+    col_base = 0
+
+    for i in 1:length(arrays)
+        arr = arrays[i]
+        ncol = size(arr, 2)
+        outer = repititions[i]
+        inner = floor(Int, l / (outer * lens[i]))
+        for col_plus in 1:ncol
+            row = 0
+            for _1 in 1:outer, ix in 1:lens[i], _2 in 1:inner
+                out[row+=1, col_base+col_plus] = arr[ix, col_plus]
             end
         end
+        col_base += ncol
     end
     return out
 end
 
-@generated function gridmake(arrays::AbstractVector...)
+@generated function gridmake(arrays::AbstractArray...)
     T = reduce(promote_type, [eltype(a) for a in arrays])
     quote
-        l = prod([length(a) for a in  arrays])
-        out = Array{$T}(l, length(arrays))
+        l = prod(_ -> size(_, 1), arrays)
+        out = Array{$T}(l, sum(_ -> size(_, 2), arrays))
         gridmake!(out, arrays...)
         out
     end
-end
-
-# type stable version if all arrays have the same eltype
-function gridmake{T}(arrays::AbstractVector{T}...)
-    out = Array{T}(prod([length(a) for a in  arrays]), length(arrays))
-    gridmake!(out, arrays...)
-    out
 end
 
 function gridmake(t::Tuple)
@@ -90,15 +83,6 @@ function gridmake(t::Tuple)
     gridmake(map(x->1:x, t)...)::Matrix{Int}
 end
 
-@generated function gridmake(arrays::Union{AbstractVector,AbstractMatrix}...)
-    T = reduce(promote_type, [eltype(a) for a in arrays])
-    quote
-        args = collect(Base.flatten([[view(arr, :, i) for i in 1:size(arr, 2)] for arr in arrays]))
-        l = prod([length(a) for a in args])
-        out = Array{$T}(l, length(args))
-        gridmake!(out, args...)
-    end
-end
 
 """
 `gridmake(arrays::Union{AbstractVector,AbstractMatrix}...)`

--- a/src/util.jl
+++ b/src/util.jl
@@ -70,14 +70,14 @@ end
 function gridmake(arrays::AbstractVector...)
     l = prod([length(a) for a in  arrays])
     T = reduce(promote_type, [eltype(a) for a in arrays])
-    out = Array(T, l, length(arrays))
+    out = Array{T}(l, length(arrays))
     gridmake!(out, arrays...)
     out
 end
 
 # type stable version if all arrays have the same eltype
 function gridmake{T}(arrays::AbstractVector{T}...)
-    out = Array(T, prod([length(a) for a in  arrays]), length(arrays))
+    out = Array{T}(prod([length(a) for a in  arrays]), length(arrays))
     gridmake!(out, arrays...)
 end
 

--- a/src/zeros.jl
+++ b/src/zeros.jl
@@ -218,8 +218,7 @@ function bisect{T<:AbstractFloat}(f::Function, x1::T, x2::T; maxiter::Int=500,
 end
 
 ## Brent's algorithm
-
-abstract BrentExtrapolation
+@compat abstract type BrentExtrapolation end
 
 immutable BrentQuadratic <: BrentExtrapolation
 end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -3,4 +3,3 @@ HDF5
 MAT
 JLD
 DataStructures
-BaseTestNext

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using QuantEcon
 using DataStructures: counter
 using Distributions: LogNormal, pdf
+using Compat
 
 if VERSION >= v"0.5-"
     using Base.Test

--- a/test/test_ddp.jl
+++ b/test/test_ddp.jl
@@ -19,7 +19,7 @@ Tests for markov/ddp.jl
     # Formulation with Dense Matrices R: n x m, Q: n x m x n
     n, m = 2, 2  # number of states, number of actions
     R = [5.0 10.0; -1.0 -Inf]
-    Q = Array(Float64, n, m, n)
+    Q = Array{Float64}(n, m, n)
     Q[:, :, 1] = [0.5 0.0; 0.0 0.0]
     Q[:, :, 2] = [0.5 1.0; 1.0 1.0]
 
@@ -125,7 +125,7 @@ Tests for markov/ddp.jl
         res = solve(ddp0, VFI)
         res.Tv[:] = 500.0
         compute_greedy!(ddp0, res)
-        @test maxabs(res.Tv - 500.0) > 0
+        @test maximum(abs, res.Tv - 500.0) > 0
     end
 
     @testset "value_iteration" begin
@@ -137,8 +137,8 @@ Tests for markov/ddp.jl
             res_init = solve(ddp_item, v_init, VFI; epsilon=epsilon)
 
             # Check v is an epsilon/2-approxmation of v_star
-            @test maxabs(res.v - v_star) < epsilon/2
-            @test maxabs(res_init.v - v_star)    < epsilon/2
+            @test maximum(abs, res.v - v_star) < epsilon/2
+            @test maximum(abs, res_init.v - v_star)    < epsilon/2
 
             # Check sigma == sigma_star.
             # NOTE we need to convert from linear to row-by-row index
@@ -183,7 +183,7 @@ Tests for markov/ddp.jl
         r1 = solve(ddp_rational, PFI)
         r2 = solve(ddp_rational, MPFI)
         r3 = solve(ddp_rational, VFI)
-        @test maxabs(r1.v-v_star) < 1e-13
+        @test maximum(abs, r1.v-v_star) < 1e-13
         @test r1.sigma == r2.sigma
         @test r1.sigma == r3.sigma
         @test r1.mc.p == r2.mc.p
@@ -197,8 +197,8 @@ Tests for markov/ddp.jl
             res_init = solve(ddp_item, v_init, MPFI)
 
                     # Check v is an epsilon/2-approxmation of v_star
-            @test maxabs(res.v - v_star) < epsilon/2
-            @test maxabs(res_init.v - v_star) < epsilon/2
+            @test maximum(abs, res.v - v_star) < epsilon/2
+            @test maximum(abs, res_init.v - v_star) < epsilon/2
 
             # Check sigma == sigma_star
             @test res.sigma == sigma_star
@@ -209,7 +209,7 @@ Tests for markov/ddp.jl
             res = solve(ddp_item, MPFI; max_iter=max_iter, epsilon=epsilon, k=k)
 
             # Check v is an epsilon/2-approxmation of v_star
-            @test maxabs(res.v - v_star) < epsilon/2
+            @test maximum(abs, res.v - v_star) < epsilon/2
 
             # Check sigma == sigma_star
             @test res.sigma == sigma_star
@@ -266,7 +266,7 @@ Tests for markov/ddp.jl
             n, m = 2, 2
             _R = [-Inf -Inf; 1.0 2.0]
 
-            _Q = Array(Float64, n, m, n)
+            _Q = Array{Float64}(n, m, n)
             _Q[:, :, 1] = [0.5 0.0; 0.0 0.0]
             _Q[:, :, 2] = [0.5 1.0; 1.0 1.0]
             _beta = 0.95

--- a/test/test_discrete_rv.jl
+++ b/test/test_discrete_rv.jl
@@ -12,12 +12,12 @@
     # test lln
     draws = draw(drv, 100000)
     c = counter(draws)
-    counts = Array(Float64, n)
+    counts = Array{Float64}(n)
     for i=1:n
         counts[i] = c[i]
     end
     counts ./= sum(counts)
 
-    @test isapprox(Base.maxabs(counts - drv.q), 0.0; atol=1e-2)
+    @test isapprox(Base.maximum(abs, counts - drv.q), 0.0; atol=1e-2)
 
 end  # testset

--- a/test/test_ecdf.jl
+++ b/test/test_ecdf.jl
@@ -1,21 +1,25 @@
 @testset "Testing ecdf.jl" begin
     # set up
-    
+
     obs = rand(40)
     e = ECDF(obs)
-    
+
     # 1.1 is larger than all obs, so ecdf should be 1
-    @test ecdf(e, 1.1) ≈ 1.0
+    @test e(1.1) ≈ 1.0
 
     # -1.0 is small than all obs, so ecdf should be 0
-    @test ecdf(e, -1.0) ≈ 0.0
+    @test e(-1.0) ≈ 0.0
+
+    # evaluate at more than more than point
+    @test e([1.1, -1.0]) ≈ [1.0, 0.0]
 
     # larger values should have larger values on ecdf
     let x = rand()
-        F_1 = ecdf(e, x)
-        F_2 = ecdf(e, x*1.1)
+        F_1 = e(x)
+        F_2 = e(x*1.1)
         @test F_1 <= F_2
     end
 
-end  # testset
 
+
+end  # testset

--- a/test/test_estspec.jl
+++ b/test/test_estspec.jl
@@ -1,5 +1,5 @@
 @testset "Testing estspec" begin
-    
+
     # set up
     x_20 = rand(20)
     x_21 = rand(21)
@@ -35,5 +35,24 @@
         @test length(smooth(x_20, window_len=6)) == length(smooth(x_20, window_len=7))
 
     end  # @testset
+
+
+    @testset "issue from http://discourse.quantecon.org/t/question-about-estspec-jl/61" begin
+        T = 150
+        rho = -0.9
+        e = randn(T)
+        x = [e[1]]
+        tmp = e[1]
+        for t = 2:T
+            tmp = rho*tmp+e[t]
+            push!(x,tmp)
+        end
+
+        for i in 3:2:69
+            ar_periodogram(x, "hamming", i)
+            # just count that the above didn't throw an error
+            @test true
+        end
+    end
 
 end  # @testset

--- a/test/test_interp.jl
+++ b/test/test_interp.jl
@@ -2,7 +2,7 @@
 
     # uniform interpolation
     breaks = linspace(-3, 3, 100)
-    vals = map(exp, breaks)
+    vals = exp.(breaks)
 
     li = interp(breaks, vals)
     li2 = LinInterp(breaks, vals)

--- a/test/test_lae.jl
+++ b/test/test_lae.jl
@@ -1,5 +1,5 @@
 @testset "Testing lae.jl" begin
-        
+
     # copied from the lae lecture
     s = 0.2
     δ = 0.1
@@ -10,7 +10,7 @@
     function p(x, y)
         d = s * x.^α
 
-        pdf_arg = clamp((y .- (1-δ) .* x) ./ d, eps(), Inf)
+        pdf_arg = clamp.((y .- (1 .- δ) .* x) ./ d, eps(), Inf)
         return pdf(ϕ, pdf_arg) ./ d
     end
 
@@ -26,7 +26,7 @@
     lae_b = LAE(p, b)
 
     laes = [lae_a, lae_b]
-    
+
     # test stuff
     for l in laes
         # make sure X is made a column vector by constructor

--- a/test/test_lss.jl
+++ b/test/test_lss.jl
@@ -13,7 +13,7 @@
     ss1 = LSS(A, C, G, mu_0, Sigma_0)
 
     vals = stationary_distributions(ss, max_iter=1000, tol=1e-9)
-    
+
     @testset "test stationarity" begin
         vals = stationary_distributions(ss, max_iter=1000, tol=1e-9)
         ssmux, ssmuy, sssigx, sssigy = vals
@@ -56,6 +56,16 @@
         for nm in fieldnames(ss)
             @test getfield(ss, nm) == getfield(other_ss, nm)
         end
+    end
+
+    @testset "test moment iterator" begin
+        m = QuantEcon.LSSMoments(ss)
+
+        # never done
+        @test !done(m, 1)
+
+        # start should give us mu_0, Sigma_0
+        @test start(m) == (ss.mu_0, ss.Sigma_0)
     end
 
 

--- a/test/test_mc_tools.jl
+++ b/test/test_mc_tools.jl
@@ -1,3 +1,7 @@
+@static if isdefined(Base, :Iterators)
+    using Base.Iterators: take, cycle
+end
+
 function kmr_markov_matrix_sequential{T<:Real}(n::Integer, p::T, ε::T)
     """
     Generate the markov matrix for the KMR model with *sequential* move
@@ -402,7 +406,7 @@ end
             @test size(simulate_indices(mc, ts_length; init=init)) ==
                        (ts_length, )
             for num_sims in nums_sims
-                X = Array(Int64, ts_length, num_sims)
+                X = Array{Int64}(ts_length, num_sims)
                 @test size(simulate_indices!(X, mc)) ==
                            (ts_length, num_sims)
                 @test size(simulate_indices!(X, mc; init=init)) ==
@@ -419,7 +423,7 @@ end
             @test Y[1] == init
 
             num_sims = 5
-            X = Array(Int64, ts_length, num_sims)
+            X = Array{Int64}(ts_length, num_sims)
             simulate_indices!(X, mc; init=init)
             @test vec(X[1, :]) == init .* ones(Int, num_sims)
 
@@ -445,7 +449,7 @@ end
 
         @testset "basic correspondence with dense version" begin
             @test n_states(mc) == n_states(mc_s)
-            @test maxabs(mc.p - mc_s.p) == 0.0
+            @test maximum(abs, mc.p - mc_s.p) == 0.0
             @test recurrent_classes(mc) == recurrent_classes(mc_s)
             @test communication_classes(mc) == communication_classes(mc_s)
             @test is_irreducible(mc) == is_irreducible(mc_s)
@@ -466,7 +470,7 @@ end
 
                 @test size(@inferred(simulate(mc, ts_length))) == (ts_length,)
                 for num_sims in nums_sims
-                    X = Array(T, ts_length, num_sims)
+                    X = Array{T}(ts_length, num_sims)
                     @test size(simulate!(X, mc)) ==
                            (ts_length, num_sims)
                     @test size(simulate!(X, mc; init=init)) ==
@@ -483,7 +487,7 @@ end
                 @test Y[1] == mc.state_values[init]
 
                 num_sims = 5
-                X = Array(eltype(mc.state_values), ts_length, num_sims)
+                X = Array{eltype(mc.state_values)}(ts_length, num_sims)
                 simulate!(X, mc; init=init)
                 @test vec(X[1, :]) == mc.state_values[init .* ones(Int, num_sims)]
 
@@ -504,7 +508,7 @@ end
         mcis = MCIndSimulator(mc, 50, 1)
 
         want = collect(take(cycle(1:4), 50))
-        have = Array(Int, 50)
+        have = Array{Int}(50)
         for (ix, i) in enumerate(mcis)
             have[ix] = i
         end

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -8,8 +8,8 @@
 
 	@testset "Golden Method, 1D" begin
         xstar, fstar = golden_method(f, a, b, maxit=10_000)
-        @test maxabs(0.5 - xstar) <= 1e-6
-    	@test maxabs(0.25 - fstar) <= 1e-6
+        @test maximum(abs, 0.5 - xstar) <= 1e-6
+    	@test maximum(abs, 0.25 - fstar) <= 1e-6
     end
 
 	# test multiD method
@@ -20,8 +20,8 @@
 
 	@testset "Golden Method, multiD" begin
         xstar, fstar = golden_method(g, a, b, maxit=10_000)
-        @test maxabs([0.5, 0.0] - xstar) <= 1e-6
-        @test maxabs([0.25, 0.0] - fstar) <= 1e-6
+        @test maximum(abs, [0.5, 0.0] - xstar) <= 1e-6
+        @test maximum(abs, [0.25, 0.0] - fstar) <= 1e-6
     end
 
 end

--- a/test/test_quad.jl
+++ b/test/test_quad.jl
@@ -96,9 +96,9 @@ x_gamm_3, w_gamm_3 = qnwgamma(n_3, b_3, ones(3))
     end
 
     @testset "testing quadrect 1d against Matlab" begin
-        f1(x) = exp(-x)
-        f2(x) = 1.0 ./ (1.0 + 25.0 .* x.^2.0)
-        f3(x) = abs(x).^0.5
+        f1(x) = exp.(-x)
+        f2(x) = 1.0 ./ (1.0 .+ 25.0 .* x .^ 2.0)
+        f3(x) = abs.(x).^0.5
 
         # dim 1: num nodes, dim2: method, dim3:func
         data1d = Array{Float64}(6, 6, 3)
@@ -128,8 +128,8 @@ x_gamm_3, w_gamm_3 = qnwgamma(n_3, b_3, ones(3))
     end
 
     @testset "testing quadrect 2d against Matlab" begin
-        f1(x) = exp(x[:, 1] + x[:, 2])
-        f2(x) = exp(- x[:, 1] .* cos(x[:, 2].^2))
+        f1(x) = exp.(x[:, 1] + x[:, 2])
+        f2(x) = exp.(- x[:, 1] .* cos.(x[:, 2].^2))
 
         a = ([0.0, 0.0], [-1.0, -1.0])
         b = ([1.0, 2.0], [1.0, 1.0])

--- a/test/test_quad.jl
+++ b/test/test_quad.jl
@@ -101,7 +101,7 @@ x_gamm_3, w_gamm_3 = qnwgamma(n_3, b_3, ones(3))
         f3(x) = abs(x).^0.5
 
         # dim 1: num nodes, dim2: method, dim3:func
-        data1d = Array(Float64, 6, 6, 3)
+        data1d = Array{Float64}(6, 6, 3)
         kinds = ["trap", "simp", "lege", "N", "W", "H"]
         n_nodes = [5, 11, 21, 51, 101, 401]  # number of nodes
         a, b = -1, 1
@@ -135,7 +135,7 @@ x_gamm_3, w_gamm_3 = qnwgamma(n_3, b_3, ones(3))
         b = ([1.0, 2.0], [1.0, 1.0])
 
         # dim 1: num nodes, dim2: method
-        data2d1 = Array(Float64, 6, 6)
+        data2d1 = Array{Float64}(6, 6)
         kinds = ["lege", "trap", "simp", "N", "W", "H"]
         n_nodes = [5, 11, 21, 51, 101, 401]  # number of nodes
 

--- a/test/test_random_mc.jl
+++ b/test/test_random_mc.jl
@@ -24,7 +24,7 @@
     @testset "Test random_stochastic_matrix with k=1" begin
         n, k = 3, 1
         P = random_stochastic_matrix(n, k)
-        @test all((P .== 0) | (P .== 1)) == true
+        @test all((P .== 0) .| (P .== 1))
         @test all(x->isequal(sum(x), 1),
                   [P[i, :] for i in 1:size(P)[1]]) == true
     end


### PR DESCRIPTION
This gets QuantEcon.jl ready for Julia 0.6.

It mostly includes cosmetic changes to use broadcasting syntax (`f.(...)`) instead of vectorized functions (`f(x...)`) and change `Array(T, ...)` to `Array{T}(...)`.

There are three substantial changes that might require changes to lectures:

1. We no longer use task based iteration for the moment sequence of the LSS type. Instead we use a new (non exported) type `LSSMoments` and define the `start`, `next`, and `done` methods for it. There is one commit dedicated to this change, so if you want to see how that changes other code take a look at that.
2. I've deprecated the `ecdf(::ECDF, x)` function in favor of a `call` method on the type. So  now instead of writing `ecdf(e, x)` we write `e(x)`. This is a true deprecation so the old syntax will still work (for now), but will emit a warning
3. We've officially dropped support for Julia 0.4. With 0.6 around the corner and 1.0 due this summer I think supporting 0.4 is not necessary. If anyone has objections to this we can still support it if we really want to, but will require us to sprinkle `@compat` in many places across the lib