### PR TITLE
BUG: Fix MVNSampler

### DIFF
--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -22,8 +22,8 @@ function MVNSampler{TM<:Real,TS<:Real}(mu::Vector{TM}, Sigma::Matrix{TS})
 
     issymmetric(Sigma) || throw(ArgumentError("Sigma must be symmetric"))
 
-    A = copy(Sigma)
-    C = cholfact!(Symmetric(A, :L), Val{true})
+    C = cholfact(Symmetric(Sigma, :L), Val{true})
+    A = C.factors
     r = C.rank
     p = invperm(C.piv)
 

--- a/test/test_sampler.jl
+++ b/test/test_sampler.jl
@@ -47,4 +47,14 @@
             @test typeof(MVNSampler(mu,Sigma)) <: MVNSampler
         end
     end
+
+    @testset "test covariance matrices of Int and Rational" begin
+        n = 2
+        mu = zeros(2)
+        for T in [Int, Rational{Int}]
+            Sigma = eye(T, n)
+            @test typeof(MVNSampler(mu, Sigma)) <: MVNSampler
+        end
+    end
+
 end  # @testset


### PR DESCRIPTION
I found my code contained a bug...

```jl
n = 2
mu = zeros(n)
Sigma = eye(Int, n)
MVNSampler(mu, Sigma)
```

```
ERROR: ArgumentError: generic pivoted Cholesky factorization is not implemented yet
 in QuantEcon.MVNSampler{TM<:Real,TS<:Real,TQ<:Union{Float32,Float64}}(::Array{Float64,1}, ::Array{Int64,2}) at /Users/oyama/.julia/v0.5/QuantEcon/src/sampler.jl:26
```