### PR TITLE
Discrete Markov chain estimation

### DIFF
--- a/src/QuantEcon.jl
+++ b/src/QuantEcon.jl
@@ -58,6 +58,7 @@ export
 # markov_approx
     tauchen,
     rouwenhorst,
+    estimate_MC_discrete,
 
 # lae
     LAE,

--- a/src/QuantEcon.jl
+++ b/src/QuantEcon.jl
@@ -58,7 +58,7 @@ export
 # markov_approx
     tauchen,
     rouwenhorst,
-    estimate_MC_discrete,
+    estimate_mc_discrete,
 
 # lae
     LAE,

--- a/src/markov/markov_approx.jl
+++ b/src/markov/markov_approx.jl
@@ -164,7 +164,7 @@ function estimate_MC_discrete{T}(X::Vector{T})
     state_i = findfirst(states, X[1])
     for t in 1:capT-1
         # Find next period's state
-        state_j = findfirst(states, X[t+1])
+        state_j = searchsortedfirst(states, X[t+1])
         cm[state_i, state_j] += 1.0
 
         # Tomorrow's state is j

--- a/src/markov/markov_approx.jl
+++ b/src/markov/markov_approx.jl
@@ -180,7 +180,7 @@ function estimate_mc_discrete{T}(X::Vector{T}, states::Vector{T})
 
     # Make sure all of the passed in states appear in X... If not
     # throw an error
-    if any(map(x->in(x, X), states) .== false)
+    if any(!in(x, X) for x in states)
         error("One of the states does not appear in history X")
     end
 

--- a/src/markov/markov_approx.jl
+++ b/src/markov/markov_approx.jl
@@ -155,6 +155,11 @@ Note: Because of the estimation procedure used, only states that are observed
 in the history appear in the estimated Markov chain... It can't divine whether
 there are unobserved states in the original Markov chain.
 
+For more info, refer to:
+
+- http://www.stat.cmu.edu/~cshalizi/462/lectures/06/markov-mle.pdf
+- https://stats.stackexchange.com/questions/47685/calculating-log-likelihood-for-given-mle-markov-chains
+
 ##### Arguments
 
 - `X::Vector{T}` : Simulated history of Markov states

--- a/src/markov/markov_approx.jl
+++ b/src/markov/markov_approx.jl
@@ -134,10 +134,26 @@ end
 
 """
 Accepts the simulation of a discrete state Markov chain and estimates
-the transition probabilities via maximum likelihood.
+the transition probabilities
 
-Note: Only states that are observed in the history will be included
-in the estimation.
+Let S = {s₁, s₂, ..., sₙ} with s₁ < s₂ < ... < sₙ be the discrete
+states of a Markov chain. Furthermore, let P be the corresponding
+stochastic transition matrix.
+
+Given a history of observations, {X} where xₜ ∈ S ∀ t, we would like
+to estimate the transition probabilities in P, pᵢⱼ. For xₜ=sᵢ and xₜ₋₁=sⱼ,
+let P(xₜ | xₜ₋₁) be the pᵢⱼ element of the stochastic matrix. The likelihood
+function is then given by
+
+    L({X}ₜ; P) = P(x_1) ∏_{t=2}^{T} P(xₜ | xₜ₋₁)
+
+The maximum likelihood estimate is then just given by the number of times
+a transition from sᵢ to sⱼ is observed divided by the number of times
+sᵢ was observed.
+
+Note: Because of the estimation procedure used, only states that are observed
+in the history appear in the estimated Markov chain... It can't divine whether
+there are unobserved states in the original Markov chain.
 
 ##### Arguments
 

--- a/src/markov/markov_approx.jl
+++ b/src/markov/markov_approx.jl
@@ -132,6 +132,10 @@ function _rouwenhorst(p::Real, q::Real, m::Real, Δ::Real, n::Integer)
 end
 
 
+# These are to help me order types other than vectors
+@inline _emcd_lt{T}(a::T, b::T) = isless(a, b)
+@inline _emcd_lt{T}(a::Vector{T}, b::Vector{T}) = Base.lt(Base.Order.Lexicographic, a, b)
+
 """
 Accepts the simulation of a discrete state Markov chain and estimates
 the transition probabilities
@@ -175,7 +179,7 @@ function estimate_MC_discrete{T}(X::Vector{T})
     capT = length(X)
 
     # Find all unique observations and sort them.
-    states = sort!(unique(X))
+    states = sort!(unique(X); lt=_emcd_lt)
     nstates = length(states)
 
     # Counter matrix
@@ -185,7 +189,7 @@ function estimate_MC_discrete{T}(X::Vector{T})
     state_i = findfirst(states, X[1])
     for t in 1:capT-1
         # Find next period's state
-        state_j = searchsortedfirst(states, X[t+1])
+        state_j = searchsortedfirst(states, X[t+1]; lt=_emcd_lt)
         cm[state_i, state_j] += 1.0
 
         # Tomorrow's state is j

--- a/src/markov/markov_approx.jl
+++ b/src/markov/markov_approx.jl
@@ -174,12 +174,17 @@ For more info, refer to:
 transition matrix
 
 """
-function estimate_mc_discrete{T}(X::Vector{T})
+function estimate_mc_discrete{T}(X::Vector{T}, states::Vector{T})
     # Get length of simulation
     capT = length(X)
 
-    # Find all unique observations, sort them, and put into dictionary
-    states = sort!(unique(X); lt=_emcd_lt)
+    # Make sure all of the passed in states appear in X... If not
+    # throw an error
+    if any(map(x->in(x, X), states) .== false)
+        error("One of the states does not appear in history X")
+    end
+
+    # Count states and store in dictionary
     nstates = length(states)
     d = Dict{T, Int}(zip(states, 1:nstates))
 
@@ -203,3 +208,9 @@ function estimate_mc_discrete{T}(X::Vector{T})
     return MarkovChain(P, states)
 end
 
+function estimate_mc_discrete{T}(X::Vector{T})
+    # Get unique states and sort them
+    states = sort!(unique(X); lt=_emcd_lt)
+
+    return estimate_mc_discrete(X, states)
+end

--- a/src/markov/markov_approx.jl
+++ b/src/markov/markov_approx.jl
@@ -130,3 +130,50 @@ function _rouwenhorst(p::Real, q::Real, m::Real, Δ::Real, n::Integer)
         return linspace(m-Δ, m+Δ, n), θN
     end
 end
+
+
+"""
+Accepts the simulation of a discrete state Markov chain and estimates
+the transition probabilities via maximum likelihood.
+
+Note: Only states that are observed in the history will be included
+in the estimation.
+
+##### Arguments
+
+- `X::Vector{T}` : Simulated history of Markov states
+
+##### Returns
+
+- `mc::MarkovChain{T}` : A Markov chain holding the state values and
+transition matrix
+
+"""
+function estimate_MC_discrete{T}(X::Vector{T})
+    # Get length of simulation
+    capT = length(X)
+
+    # Find all unique observations and sort them.
+    states = sort!(unique(X))
+    nstates = length(states)
+
+    # Counter matrix
+    cm = zeros(nstates, nstates)
+
+    # Compute conditional probabilities for each state
+    state_i = findfirst(states, X[1])
+    for t in 1:capT-1
+        # Find next period's state
+        state_j = findfirst(states, X[t+1])
+        cm[state_i, state_j] += 1.0
+
+        # Tomorrow's state is j
+        state_i = state_j
+    end
+
+    # Compute probabilities using counted elements
+    P = cm ./ sum(cm, 2)
+
+    return MarkovChain(P, states)
+end
+

--- a/src/markov/markov_approx.jl
+++ b/src/markov/markov_approx.jl
@@ -174,22 +174,23 @@ For more info, refer to:
 transition matrix
 
 """
-function estimate_MC_discrete{T}(X::Vector{T})
+function estimate_mc_discrete{T}(X::Vector{T})
     # Get length of simulation
     capT = length(X)
 
-    # Find all unique observations and sort them.
+    # Find all unique observations, sort them, and put into dictionary
     states = sort!(unique(X); lt=_emcd_lt)
     nstates = length(states)
+    d = Dict{T, Int}(zip(states, 1:nstates))
 
-    # Counter matrix
+    # Counter matrix and dictionary mapping i -> states
     cm = zeros(nstates, nstates)
 
     # Compute conditional probabilities for each state
-    state_i = findfirst(states, X[1])
+    state_i = d[X[1]]
     for t in 1:capT-1
         # Find next period's state
-        state_j = searchsortedfirst(states, X[t+1]; lt=_emcd_lt)
+        state_j = d[X[t]]
         cm[state_i, state_j] += 1.0
 
         # Tomorrow's state is j

--- a/test/test_markov_approx.jl
+++ b/test/test_markov_approx.jl
@@ -18,11 +18,22 @@
     end
 
 
+    #
     # Test discrete estimation
+    #
     P = [0.5 0.25 0.25
          0.25 0.5 0.25
          0.25 0.25 0.5]
+
+    # Test with numerical inputs
     mc = MarkovChain(P, [0.0, 0.5, 1.0])
+    X = simulate(mc, 100_000)
+    mc2 = estimate_MC_discrete(X)
+    @test isapprox(mc.state_values, mc2.state_values, atol=1e-10)
+    @test isapprox(mc.p, mc2.p, atol=1e-2)
+
+    # Test with other inputs
+    mc = MarkovChain(P, ["a", "b", "c"])
     X = simulate(mc, 100_000)
     mc2 = estimate_MC_discrete(X)
     @test isapprox(mc.state_values, mc2.state_values, atol=1e-10)

--- a/test/test_markov_approx.jl
+++ b/test/test_markov_approx.jl
@@ -30,14 +30,14 @@
     mc = MarkovChain(P, [0.0, 0.5, 1.0])
     X = simulate(mc, 100_000)
     mc2 = estimate_MC_discrete(X)
-    @test isapprox(mc.state_values, mc2.state_values, atol=1e-10)
-    @test isapprox(mc.p, mc2.p, atol=1e-2)
+    @test isequal(mc.state_values, mc2.state_values)
+    @test isapprox(mc.p, mc2.p; atol=1e-2)
 
     # Test with other inputs
     mc = MarkovChain(P, ["a", "b", "c"])
     X = simulate(mc, 100_000)
     mc2 = estimate_MC_discrete(X)
-    @test isapprox(mc.state_values, mc2.state_values, atol=1e-10)
+    @test isequal(mc.state_values, mc2.state_values)
     @test isapprox(mc.p, mc2.p, atol=1e-2)
 
     # Test with subset of states
@@ -47,7 +47,7 @@
     mc = MarkovChain(P, [1, 2, 3])
     X = simulate(mc, 100_000, init=1)
     mc2 = estimate_MC_discrete(X)
-    @test isapprox(mc.state_values[1:2], mc2.state_values, atol=1e-10)
+    @test isequal(mc.state_values[1:2], mc2.state_values)
     @test isapprox(mc.p[1:2, 1:2], mc2.p, atol=1e-2)
 
 end  # @testset

--- a/test/test_markov_approx.jl
+++ b/test/test_markov_approx.jl
@@ -16,4 +16,16 @@
             @test isapprox(sum(mc.state_values), 0.0; rough_kwargs...)
         end
     end
+
+
+    # Test discrete estimation
+    P = [0.5 0.25 0.25
+         0.25 0.5 0.25
+         0.25 0.25 0.5]
+    mc = MarkovChain(P, [0.0, 0.5, 1.0])
+    X = simulate(mc, 100_000)
+    mc2 = estimate_MC_discrete(X)
+    @test isapprox(mc.state_values, mc2.state_values, atol=1e-10)
+    @test isapprox(mc.p, mc2.p, atol=1e-2)
+
 end  # @testset

--- a/test/test_markov_approx.jl
+++ b/test/test_markov_approx.jl
@@ -21,6 +21,7 @@
     #
     # Test discrete estimation
     #
+    srand(42)
     P = [0.5 0.25 0.25
          0.25 0.5 0.25
          0.25 0.25 0.5]
@@ -38,5 +39,15 @@
     mc2 = estimate_MC_discrete(X)
     @test isapprox(mc.state_values, mc2.state_values, atol=1e-10)
     @test isapprox(mc.p, mc2.p, atol=1e-2)
+
+    # Test with subset of states
+    P = [0.5 0.5 0.0
+         0.5 0.5 0.0
+         0.0 0.5 0.5]
+    mc = MarkovChain(P, [1, 2, 3])
+    X = simulate(mc, 100_000, init=1)
+    mc2 = estimate_MC_discrete(X)
+    @test isapprox(mc.state_values[1:2], mc2.state_values, atol=1e-10)
+    @test isapprox(mc.p[1:2, 1:2], mc2.p, atol=1e-2)
 
 end  # @testset

--- a/test/test_markov_approx.jl
+++ b/test/test_markov_approx.jl
@@ -29,14 +29,14 @@
     # Test with numerical inputs
     mc = MarkovChain(P, [0.0, 0.5, 1.0])
     X = simulate(mc, 100_000)
-    mc2 = estimate_MC_discrete(X)
+    mc2 = estimate_mc_discrete(X)
     @test isequal(mc.state_values, mc2.state_values)
     @test isapprox(mc.p, mc2.p; atol=1e-2)
 
     # Test with other inputs
     mc = MarkovChain(P, ["a", "b", "c"])
     X = simulate(mc, 100_000)
-    mc2 = estimate_MC_discrete(X)
+    mc2 = estimate_mc_discrete(X)
     @test isequal(mc.state_values, mc2.state_values)
     @test isapprox(mc.p, mc2.p, atol=1e-2)
 
@@ -46,8 +46,19 @@
          0.0 0.5 0.5]
     mc = MarkovChain(P, [1, 2, 3])
     X = simulate(mc, 100_000, init=1)
-    mc2 = estimate_MC_discrete(X)
+    mc2 = estimate_mc_discrete(X)
     @test isequal(mc.state_values[1:2], mc2.state_values)
     @test isapprox(mc.p[1:2, 1:2], mc2.p, atol=1e-2)
+
+    # Test with vector states
+    P = [0.5 0.25 0.25
+         0.25 0.5 0.25
+         0.25 0.25 0.5]
+    mc = MarkovChain(P, [[1.0, 2.0], [1.0, 3.0], [2.0, 3.0]])
+    X = simulate(mc, 100_000)
+    mc2 = estimate_mc_discrete(X)
+    @test isequal(mc.state_values, mc2.state_values)
+    @test isapprox(mc.p, mc2.p, atol=1e-2)
+
 
 end  # @testset

--- a/test/test_markov_approx.jl
+++ b/test/test_markov_approx.jl
@@ -29,7 +29,7 @@
     # Test with numerical inputs
     mc = MarkovChain(P, [0.0, 0.5, 1.0])
     X = simulate(mc, 100_000)
-    mc2 = estimate_mc_discrete(X)
+    mc2 = estimate_mc_discrete(X, mc.state_values)
     @test isequal(mc.state_values, mc2.state_values)
     @test isapprox(mc.p, mc2.p; atol=1e-2)
 

--- a/test/test_markov_approx.jl
+++ b/test/test_markov_approx.jl
@@ -33,6 +33,8 @@
     @test isequal(mc.state_values, mc2.state_values)
     @test isapprox(mc.p, mc2.p; atol=1e-2)
 
+    @test_throws ErrorException estimate_mc_discrete(X, [0.0, 0.5, 1.0, 1.5])
+
     # Test with other inputs
     mc = MarkovChain(P, ["a", "b", "c"])
     X = simulate(mc, 100_000)


### PR DESCRIPTION
Threw this together for kicks and giggles last night (it was a 15 minute exercise) in response to the [discourse thread](http://discourse.quantecon.org/t/estimate-markovchain-from-data-using-ml/239/2) by @jstac 

Uses maximum likelihood estimation to get transition matrix for a discrete number of states.

Attn: @jstac @sglyon 