### PR TITLE
add latex support to documenter

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,6 +19,6 @@ deploydocs(
     branch = "gh-pages",
     target = "build",
     julia  = "0.5",
-    deps = nothing,
+    deps = Deps.pip("pygments", "mkdocs", "python-markdown-math"),
     make = nothing,
 )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,3 +15,10 @@ pages:
 - Overview: 'api/index.md'
 - API Docs:
   - QuantEcon: 'api/QuantEcon.md'
+
+markdown_extensions:
+  - mdx_math
+  
+extra_javascript:
+- https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML
+- assets/mathjaxhelper.js

--- a/src/arma.jl
+++ b/src/arma.jl
@@ -21,7 +21,9 @@ Represents a scalar ARMA(p, q) process
 If phi and theta are scalars, then the model is
 understood to be
 
-    X_t = phi X_{t-1} + epsilon_t + theta epsilon_{t-1}
+```math
+X_t = \phi X_{t-1} + \epsilon_t + \theta \epsilon_{t-1}
+```
 
 where epsilon_t is a white noise process with standard
 deviation sigma.


### PR DESCRIPTION
Hi @sglyon, this should add support for latex in Documenter.jl

Would you and @mmcky be able to test this?
@mmcky can you see if there is an equivalent of readthedocs to trigger a build of this branch of the documentation

Info is here: https://juliadocs.github.io/Documenter.jl/v0.1.3/

arma.jl docstring has been edited for testing