### PR TITLE
Latex rendering in docs + other improvements

### DIFF
--- a/src/arma.jl
+++ b/src/arma.jl
@@ -22,7 +22,7 @@ If ``\phi`` and ``\theta`` are scalars, then the model is
 understood to be
 
 ```math
-X_t = \phi X_{t-1} + \epsilon_t + \theta \epsilon_{t-1}
+    X_t = \phi X_{t-1} + \epsilon_t + \theta \epsilon_{t-1}
 ```
 
 where ``\epsilon_t`` is a white noise process with standard
@@ -32,9 +32,9 @@ If ``\phi`` and ``\theta`` are arrays or sequences,
 then the interpretation is the ARMA(p, q) model
 
 ```math
-X_t = \phi_1 X_{t-1} + ... + \phi_p X_{t-p} +
-\epsilon_t + \theta_1 \epsilon_{t-1} + \ldots  +
-\theta_q \epsilon_{t-q}
+    X_t = \phi_1 X_{t-1} + ... + \phi_p X_{t-p} +
+    \epsilon_t + \theta_1 \epsilon_{t-1} + \ldots  +
+    \theta_q \epsilon_{t-q}
 ```
 
 where
@@ -98,7 +98,7 @@ The spectral density is the discrete time Fourier transform of the
 autocovariance function. In particular,
 
 ```math
-f(w) = \sum_k \gamma(k) \exp(-ikw)
+    f(w) = \sum_k \gamma(k) \exp(-ikw)
 ```
 
 where ``\gamma`` is the autocovariance function and the sum is over
@@ -108,10 +108,10 @@ the set of all integers.
 
 - `arma::ARMA`: Instance of `ARMA` type
 - `;two_pi::Bool(true)`: Compute the spectral density function over ``[0, \pi]``
-if false and ``[0, 2 \pi]`` otherwise.
+  if false and ``[0, 2 \pi]`` otherwise.
 - `;res(1200)` : If `res` is a scalar then the spectral density is computed at
-`res` frequencies evenly spaced around the unit circle, but if `res` is an array
-then the function computes the response at the frequencies given by the array
+  `res` frequencies evenly spaced around the unit circle, but if `res` is an array
+  then the function computes the response at the frequencies given by the array
 
 
 ##### Returns
@@ -131,7 +131,7 @@ end
 
 """
 Compute the autocovariance function from the ARMA parameters
-over the integers range(num_autocov) using the spectral density
+over the integers range(`num_autocov`) using the spectral density
 and the inverse Fourier transform.
 
 ##### Arguments
@@ -155,14 +155,13 @@ Get the impulse response corresponding to our model.
 ##### Arguments
 
 - `arma::ARMA`: Instance of `ARMA` type
-- `;impulse_length::Integer(30)`: Length of horizon for calucluating impulse
-reponse. Must be at least as long as the `p` fields of `arma`
+- `;impulse_length::Integer(30)`: Length of horizon for calcluating impulse reponse. Must be at least as long as the `p` fields of `arma`
 
 
 ##### Returns
 
 - `psi::Vector{Float64}`: `psi[j]` is the response at lag j of the impulse
-response. We take `psi[1]` as unity.
+  response. We take `psi[1]` as unity.
 
 """
 function impulse_response(arma::ARMA; impulse_length=30)
@@ -190,7 +189,7 @@ Compute a simulated sample path assuming Gaussian shocks.
 - `arma::ARMA`: Instance of `ARMA` type
 - `;ts_length::Integer(90)`: Length of simulation
 - `;impulse_length::Integer(30)`: Horizon for calculating impulse response
-(see also docstring for `impulse_response`)
+  (see also docstring for `impulse_response`)
 
 ##### Returns
 

--- a/src/compute_fp.jl
+++ b/src/compute_fp.jl
@@ -9,24 +9,24 @@ specified initial condition v.
 References
 ----------
 
-http://quant-econ.net/jl/dp_intro.html
+https://lectures.quantecon.org/jl/optgrowth.html
 =#
 
 
-"""
+doc"""
 Repeatedly apply a function to search for a fixed point
 
-Approximates `T^∞ v`, where `T` is an operator (function) and `v` is an initial
+Approximates ``T^∞ v``, where ``T`` is an operator (function) and ``v`` is an initial
 guess for the fixed point. Will terminate either when `T^{k+1}(v) - T^k v <
 err_tol` or `max_iter` iterations has been exceeded.
 
-Provided that `T` is a contraction mapping or similar,  the return value will
-be an approximation to the fixed point of `T`.
+Provided that ``T`` is a contraction mapping or similar,  the return value will
+be an approximation to the fixed point of ``T``.
 
 ##### Arguments
 
-* `T`: A function representing the operator `T`
-* `v::TV`: The initial condition. An object of type `TV`
+* `T`: A function representing the operator ``T``
+* `v::TV`: The initial condition. An object of type ``TV``
 * `;err_tol(1e-3)`: Stopping tolerance for iterations
 * `;max_iter(50)`: Maximum number of iterations
 * `;verbose(2)`: Level of feedback (0 for no output, 1 for warnings only, 2
@@ -37,7 +37,7 @@ be an approximation to the fixed point of `T`.
 ##### Returns
 ---
 
-* '::TV': The fixed point of the operator `T`. Has type `TV`
+* '::TV': The fixed point of the operator ``T``. Has type ``TV``
 
 ##### Example
 

--- a/src/discrete_rv.jl
+++ b/src/discrete_rv.jl
@@ -21,12 +21,12 @@ TODO: as of 07/10/2014 it is not possible to define the property
 
 """
 Generates an array of draws from a discrete random variable with
-vector of probabilities given by q.
+vector of probabilities given by `q`.
 
 ##### Fields
 
 - `q::AbstractVector`: A vector of non-negative probabilities that sum to 1
-- `Q::AbstractVector`: The cumulative sum of q
+- `Q::AbstractVector`: The cumulative sum of `q`
 """
 type DiscreteRV{TV1<:AbstractVector, TV2<:AbstractVector}
     q::TV1

--- a/src/discrete_rv.jl
+++ b/src/discrete_rv.jl
@@ -43,7 +43,7 @@ function DiscreteRV{TV<:AbstractVector}(q::TV)
 end
 
 """
-Make a single draw from the discrete distribution
+Make a single draw from the discrete distribution.
 
 ##### Arguments
 
@@ -62,7 +62,7 @@ Make multiple draws from the discrete distribution represented by a
 ##### Arguments
 
 - `d::DiscreteRV`: The `DiscreteRV` type representing the distribution
-- `k::Int`:
+- `k::Int`
 
 ##### Returns
 

--- a/src/discrete_rv.jl
+++ b/src/discrete_rv.jl
@@ -10,7 +10,7 @@ specified vector of probabilities.
 References
 ----------
 
-http://quant-econ.net/jl/finite_markov.html?highlight=discrete_rv
+https://lectures.quantecon.org/jl/finite_markov.html
 
 
 TODO: as of 07/10/2014 it is not possible to define the property

--- a/src/estspec.jl
+++ b/src/estspec.jl
@@ -8,7 +8,7 @@ Functions for working with periodograms of scalar data.
 References
 ----------
 
-http://quant-econ.net/jl/estspec.html
+https://lectures.quantecon.org/jl/estspec.html
 
 =#
 import DSP
@@ -90,14 +90,16 @@ function periodogram(x::Vector, window::AbstractString, window_len::Int=7)
     return w, I_w
 end
 
-"""
+doc"""
 Computes the periodogram
 
-    I(w) = (1 / n) | sum_{t=0}^{n-1} x_t e^{itw} |^2
+```math
+I(w) = (1 / n) | \sum_{t=0}^{n-1} x_t e^{itw} |^2
+```
 
-at the Fourier frequences w_j := 2 pi j / n, j = 0, ..., n - 1, using the fast
-Fourier transform.  Only the frequences w_j in [0, pi] and corresponding values
-I(w_j) are returned.  If a window type is given then smoothing is performed.
+at the Fourier frequences ``w_j := 2 pi j / n, j = 0, \ldots, n - 1``, using the fast
+Fourier transform.  Only the frequences ``w_j`` in ``[0, \pi]`` and corresponding values
+``I(w_j)`` are returned.  If a window type is given then smoothing is performed.
 
 ##### Arguments
 

--- a/src/estspec.jl
+++ b/src/estspec.jl
@@ -20,8 +20,8 @@ Smooth the data in x using convolution with a window of requested size and type.
 
 - `x::Array`: An array containing the data to smooth
 - `window_len::Int(7)`: An odd integer giving the length of the window
-- `window::AbstractString("hanning")`: A string giving the window type. Possible values
-are `flat`, `hanning`, `hamming`, `bartlett`, or `blackman`
+- `window::AbstractString("hanning")`: A string giving the window type. 
+  Possible values are `flat`, `hanning`, `hamming`, `bartlett`, or `blackman`
 
 ##### Returns
 
@@ -94,10 +94,10 @@ doc"""
 Computes the periodogram
 
 ```math
-I(w) = (1 / n) | \sum_{t=0}^{n-1} x_t e^{itw} |^2
+I(w) = \frac{1}{n} | \sum_{t=0}^{n-1} x_t e^{itw} |^2
 ```
 
-at the Fourier frequences ``w_j := 2 pi j / n, j = 0, \ldots, n - 1``, using the fast
+at the Fourier frequences ``w_j := 2 \frac{\pi j}{n}, j = 0, \ldots, n - 1``, using the fast
 Fourier transform.  Only the frequences ``w_j`` in ``[0, \pi]`` and corresponding values
 ``I(w_j)`` are returned.  If a window type is given then smoothing is performed.
 
@@ -106,7 +106,7 @@ Fourier transform.  Only the frequences ``w_j`` in ``[0, \pi]`` and correspondin
 - `x::Array`: An array containing the data to smooth
 - `window_len::Int(7)`: An odd integer giving the length of the window
 - `window::AbstractString("hanning")`: A string giving the window type. Possible values
-are `flat`, `hanning`, `hamming`, `bartlett`, or `blackman`
+  are `flat`, `hanning`, `hamming`, `bartlett`, or `blackman`
 
 ##### Returns
 
@@ -127,7 +127,7 @@ coefficients are then used for recoloring.
 - `x::Array`: An array containing the data to smooth
 - `window_len::Int(7)`: An odd integer giving the length of the window
 - `window::AbstractString("hanning")`: A string giving the window type. Possible values
-are `flat`, `hanning`, `hamming`, `bartlett`, or `blackman`
+  are `flat`, `hanning`, `hamming`, `bartlett`, or `blackman`
 
 ##### Returns
 

--- a/src/interp.jl
+++ b/src/interp.jl
@@ -3,10 +3,8 @@ Linear interpolation in one dimension
 
 ##### Fields
 
-- `breaks::AbstractVector` : A sorted array of grid points on which to
-interpolate
-- `vals::AbstractVector` : The function values associated with each of the grid
-points
+- `breaks::AbstractVector` : A sorted array of grid points on which to interpolate
+- `vals::AbstractVector` : The function values associated with each of the grid points
 
 ##### Examples
 

--- a/src/kalman.jl
+++ b/src/kalman.jl
@@ -8,7 +8,7 @@ Implements the Kalman filter for a linear Gaussian state space model.
 References
 ----------
 
-http://quant-econ.net/jl/kalman.html
+https://lectures.quantecon.org/jl/kalman.html
 
 
 TODO: Do docstrings here after implementing LinerStateSpace
@@ -42,14 +42,17 @@ function set_state!(k::Kalman, x_hat, Sigma)
     Void
 end
 
-"""
-Updates the moments (cur_x_hat, cur_sigma) of the time t prior to the
-time t filtering distribution, using current measurement y_t.
+doc"""
+Updates the moments (`cur_x_hat`, `cur_sigma`) of the time ``t`` prior to the
+time ``t` filtering distribution, using current measurement ``y_t``.
 The updates are according to
-    x_{hat}^F = x_{hat} + Sigma G' (G Sigma G' + R)^{-1}
-                    (y - G x_{hat})
-    Sigma^F = Sigma - Sigma G' (G Sigma G' + R)^{-1} G
-                Sigma
+
+```math
+\hat{x}^F = \hat{x} + \Sigma G' (G \Sigma G' + R)^{-1}
+                (y - G \hat{x})
+\Sigma^F = \Sigma - \Sigma G' (G \Sigma G' + R)^{-1} G
+           \Sigma
+```
 
 #### Arguments
 
@@ -95,7 +98,7 @@ function filtered_to_forecast!(k::Kalman)
 end
 
 """
-Updates cur_x_hat and cur_sigma given array `y` of length `k`.  The full
+Updates `cur_x_hat` and `cur_sigma` given array `y` of length `k`.  The full
 update, from one period to the next
 
 #### Arguments

--- a/src/kalman.jl
+++ b/src/kalman.jl
@@ -44,12 +44,13 @@ end
 
 doc"""
 Updates the moments (`cur_x_hat`, `cur_sigma`) of the time ``t`` prior to the
-time ``t` filtering distribution, using current measurement ``y_t``.
+time ``t`` filtering distribution, using current measurement ``y_t``.
 The updates are according to
 
 ```math
     \hat{x}^F = \hat{x} + \Sigma G' (G \Sigma G' + R)^{-1}
-                    (y - G \hat{x})
+                    (y - G \hat{x}) \\
+                    
     \Sigma^F = \Sigma - \Sigma G' (G \Sigma G' + R)^{-1} G
                \Sigma
 ```

--- a/src/kalman.jl
+++ b/src/kalman.jl
@@ -48,10 +48,10 @@ time ``t` filtering distribution, using current measurement ``y_t``.
 The updates are according to
 
 ```math
-\hat{x}^F = \hat{x} + \Sigma G' (G \Sigma G' + R)^{-1}
-                (y - G \hat{x})
-\Sigma^F = \Sigma - \Sigma G' (G \Sigma G' + R)^{-1} G
-           \Sigma
+    \hat{x}^F = \hat{x} + \Sigma G' (G \Sigma G' + R)^{-1}
+                    (y - G \hat{x})
+    \Sigma^F = \Sigma - \Sigma G' (G \Sigma G' + R)^{-1} G
+               \Sigma
 ```
 
 #### Arguments
@@ -78,9 +78,9 @@ function prior_to_filtered!(k::Kalman, y)
 end
 
 """
-Updates the moments of the time t filtering distribution to the
+Updates the moments of the time ``t`` filtering distribution to the
 moments of the predictive distribution, which becomes the time
-t+1 prior
+``t+1`` prior
 
 #### Arguments
 - `k::Kalman` An instance of the Kalman filter

--- a/src/lae.jl
+++ b/src/lae.jl
@@ -15,13 +15,13 @@ This is a density in y.
 References
 ----------
 
-http://quant-econ.net/jl/stationary_densities.html
+https://lectures.quantecon.org/jl/stationary_densities.html
 =#
 
 
 """
-A look ahead estimator associated with a given stochastic kernel p and a vector
-of observations X.
+A look ahead estimator associated with a given stochastic kernel `p` and a vector
+of observations `X`.
 
 ##### Fields
 
@@ -43,7 +43,7 @@ end
 
 """
 A vectorized function that returns the value of the look ahead estimate at the
-values in the array y.
+values in the array `y`.
 
 ##### Arguments
 

--- a/src/lae.jl
+++ b/src/lae.jl
@@ -26,9 +26,9 @@ of observations `X`.
 ##### Fields
 
 - `p::Function`: The stochastic kernel. Signature is `p(x, y)` and it should be
-vectorized in both inputs
+  vectorized in both inputs
 - `X::Matrix`: A vector containing observations. Note that this can be passed as
-any kind of `AbstractArray` and will be coerced into an `n x 1` vector.
+  any kind of `AbstractArray` and will be coerced into an `n x 1` vector.
 
 """
 type LAE

--- a/src/lqcontrol.jl
+++ b/src/lqcontrol.jl
@@ -10,39 +10,49 @@ problems.
 References
 ----------
 
-http://quant-econ.net/jl/lqcontrol.html
+https://lectures.quantecon.org/jl/lqcontrol.html
 
 =#
 
-"""
+doc"""
 Linear quadratic optimal control of either infinite or finite horizon
 
 The infinite horizon problem can be written
 
-    min E sum_{t=0}^{infty} beta^t r(x_t, u_t)
+```math
+\min \mathbb{E} \sum_{t=0}^{\infty} \beta^t r(x_t, u_t)
+```
 
 with
 
-    r(x_t, u_t) := x_t' R x_t + u_t' Q u_t + 2 u_t' N x_t
+```math
+r(x_t, u_t) := x_t' R x_t + u_t' Q u_t + 2 u_t' N x_t
+```
 
 The finite horizon form is
 
-    min E sum_{t=0}^{T-1} beta^t r(x_t, u_t) + beta^T x_T' R_f x_T
+```math
+\min \mathbb{E} \sum_{t=0}^{T-1} \beta^t r(x_t, u_t) + \beta^T x_T' R_f x_T
+```
 
 Both are minimized subject to the law of motion
 
-    x_{t+1} = A x_t + B u_t + C w_{t+1}
+```math
+x_{t+1} = A x_t + B u_t + C w_{t+1}
+```
 
-Here x is n x 1, u is k x 1, w is j x 1 and the matrices are conformable for
-these dimensions.  The sequence {w_t} is assumed to be white noise, with zero
-mean and E w_t w_t' = I, the j x j identity.
+Here ``x`` is n x 1, ``u`` is k x 1, ``w`` is j x 1 and the matrices are conformable for
+these dimensions.  The sequence ``{w_t}`` is assumed to be white noise, with zero
+mean and ``\mathbb{E} w_t w_t' = I``, the j x j identity.
 
-For this model, the time t value (i.e., cost-to-go) function V_t takes the form
+For this model, the time ``t`` value (i.e., cost-to-go) function ``V_t`` takes the form
 
-    x' P_T x + d_T
+```math
+x' P_T x + d_T
+```
 
-and the optimal policy is of the form u_T = -F_T x_T.  In the infinite horizon
-case, V, P, d and F are all stationary.
+and the optimal policy is of the form ``u_T = -F_T x_T``.  In the infinite horizon
+case, ``V, P, d`` and ``F`` are all stationary.
 
 ##### Fields
 
@@ -166,7 +176,7 @@ function update_values!(lq::LQ)
     lq.P, lq.d = new_P, new_d
 end
 
-"""
+doc"""
 Computes value and policy functions in infinite horizon model
 
 ##### Arguments
@@ -175,8 +185,7 @@ Computes value and policy functions in infinite horizon model
 
 ##### Returns
 
-- `P::ScalarOrArray` : n x n matrix in value function representation
-V(x) = x'Px + d
+- `P::ScalarOrArray` : n x n matrix in value function representation ``V(x) = x'Px + d``
 - `d::Real` : Constant in value function representation
 - `F::ScalarOrArray` : Policy rule that specifies optimal control in each period
 
@@ -209,7 +218,7 @@ end
 """
 Non-mutating routine for solving for `P`, `d`, and `F` in infinite horizon model
 
-See docstring for stationary_values! for more explanation
+See docstring for `stationary_values!` for more explanation
 """
 function stationary_values(lq::LQ)
     _lq = LQ(copy(lq.Q),
@@ -276,25 +285,20 @@ function _compute_sequence{T}(lq::LQ, x0::Vector{T}, policies)
     x_path, u_path, w_path
 end
 
-"""
-Compute and return the optimal state and control sequence, assuming innovation N(0,1)
+doc"""
+Compute and return the optimal state and control sequence, assuming innovation ``N(0,1)``
 
 ##### Arguments
 
 - `lq::LQ` : instance of `LQ` type
 - `x0::ScalarOrArray`: initial state
-- `ts_length::Integer(100)` : maximum number of periods for which to return
-process. If `lq` instance is finite horizon type, the sequenes are returned
-only for `min(ts_length, lq.capT)`
+- `ts_length::Integer(100)` : maximum number of periods for which to return process. If `lq` instance is finite horizon type, the sequenes are returned only for `min(ts_length, lq.capT)`
 
 ##### Returns
 
-- `x_path::Matrix{Float64}` : An n x T+1 matrix, where the t-th column
-represents `x_t`
-- `u_path::Matrix{Float64}` : A k x T matrix, where the t-th column represents
-`u_t`
-- `w_path::Matrix{Float64}` : A n x T+1 matrix, where the t-th column represents
-`lq.C*N(0,1)`
+- `x_path::Matrix{Float64}` : An n x T+1 matrix, where the t-th column represents `x_t`
+- `u_path::Matrix{Float64}` : A k x T matrix, where the t-th column represents `u_t`
+- `w_path::Matrix{Float64}` : A n x T+1 matrix, where the t-th column represents `lq.C*N(0,1)`
 
 """
 function compute_sequence(lq::LQ, x0::ScalarOrArray, ts_length::Integer=100)

--- a/src/lqcontrol.jl
+++ b/src/lqcontrol.jl
@@ -56,19 +56,19 @@ case, ``V, P, d`` and ``F`` are all stationary.
 
 ##### Fields
 
-- `Q::ScalarOrArray` : k x k payoff coefficient for control variable u. Must be
+- `Q::ScalarOrArray` : `k x k` payoff coefficient for control variable u. Must be
 symmetric and nonnegative definite
-- `R::ScalarOrArray` : n x n payoff coefficient matrix for state variable x.
+- `R::ScalarOrArray` : `n x n` payoff coefficient matrix for state variable x.
 Must be symmetric and nonnegative definite
-- `A::ScalarOrArray` : n x n coefficient on state in state transition
-- `B::ScalarOrArray` : n x k coefficient on control in state transition
-- `C::ScalarOrArray` : n x j coefficient on random shock in state transition
-- `N::ScalarOrArray` : k x n cross product in payoff equation
-- `bet::Real` : Discount factor in [0, 1]
+- `A::ScalarOrArray` : `n x n` coefficient on state in state transition
+- `B::ScalarOrArray` : `n x k` coefficient on control in state transition
+- `C::ScalarOrArray` : `n x j` coefficient on random shock in state transition
+- `N::ScalarOrArray` : `k x n` cross product in payoff equation
+- `bet::Real` : Discount factor in `[0, 1]`
 - `capT::Union{Int, Void}` : Terminal period in finite horizon problem
 - `rf::ScalarOrArray` : n x n terminal payoff in finite horizon problem. Must be
 symmetric and nonnegative definite
-- `P::ScalarOrArray` : n x n matrix in value function representation
+- `P::ScalarOrArray` : `n x n` matrix in value function representation
 V(x) = x'Px + d
 - `d::Real` : Constant in value function representation
 - `F::ScalarOrArray` : Policy rule that specifies optimal control in each period
@@ -99,20 +99,20 @@ transition equation.
 
 ##### Arguments
 
-- `Q::ScalarOrArray` : k x k payoff coefficient for control variable u. Must be
+- `Q::ScalarOrArray` : `k x k` payoff coefficient for control variable u. Must be
 symmetric and nonnegative definite
-- `R::ScalarOrArray` : n x n payoff coefficient matrix for state variable x.
+- `R::ScalarOrArray` : `n x n` payoff coefficient matrix for state variable x.
 Must be symmetric and nonnegative definite
-- `A::ScalarOrArray` : n x n coefficient on state in state transition
-- `B::ScalarOrArray` : n x k coefficient on control in state transition
-- `;C::ScalarOrArray{zeros(size(R}(1)))` : n x j coefficient on random shock in
+- `A::ScalarOrArray` : `n x n` coefficient on state in state transition
+- `B::ScalarOrArray` : `n x k` coefficient on control in state transition
+- `;C::ScalarOrArray{zeros(size(R}(1)))` : `n x j` coefficient on random shock in
 state transition
-- `;N::ScalarOrArray{zeros(size(B,1)}(size(A, 2)))` : k x n cross product in
+- `;N::ScalarOrArray{zeros(size(B,1)}(size(A, 2)))` : `k x n` cross product in
 payoff equation
-- `;bet::Real(1.0)` : Discount factor in [0, 1]
+- `;bet::Real(1.0)` : Discount factor in `[0, 1]`
 - `capT::Union{Int, Void}(Void)` : Terminal period in finite horizon
 problem
-- `rf::ScalarOrArray{fill(NaN}(size(R)...))` : n x n terminal payoff in finite
+- `rf::ScalarOrArray{fill(NaN}(size(R)...))` : `n x n` terminal payoff in finite
 horizon problem. Must be symmetric and nonnegative definite.
 
 """
@@ -144,7 +144,7 @@ Update `P` and `d` from the value function representation in finite horizon case
 
 ##### Returns
 
-- `P::ScalarOrArray` : n x n matrix in value function representation
+- `P::ScalarOrArray` : `n x n` matrix in value function representation
 V(x) = x'Px + d
 - `d::Real` : Constant in value function representation
 
@@ -296,9 +296,9 @@ Compute and return the optimal state and control sequence, assuming innovation `
 
 ##### Returns
 
-- `x_path::Matrix{Float64}` : An n x T+1 matrix, where the t-th column represents `x_t`
-- `u_path::Matrix{Float64}` : A k x T matrix, where the t-th column represents `u_t`
-- `w_path::Matrix{Float64}` : A n x T+1 matrix, where the t-th column represents `lq.C*N(0,1)`
+- `x_path::Matrix{Float64}` : An `n x T+1` matrix, where the t-th column represents ``x_t``
+- `u_path::Matrix{Float64}` : A `k x T` matrix, where the t-th column represents ``u_t``
+- `w_path::Matrix{Float64}` : A `n x T+1` matrix, where the t-th column represents `lq.C*N(0,1)`
 
 """
 function compute_sequence(lq::LQ, x0::ScalarOrArray, ts_length::Integer=100)

--- a/src/lqcontrol.jl
+++ b/src/lqcontrol.jl
@@ -57,16 +57,16 @@ case, ``V, P, d`` and ``F`` are all stationary.
 ##### Fields
 
 - `Q::ScalarOrArray` : `k x k` payoff coefficient for control variable u. Must be
-symmetric and nonnegative definite
+  symmetric and nonnegative definite
 - `R::ScalarOrArray` : `n x n` payoff coefficient matrix for state variable x.
-Must be symmetric and nonnegative definite
+  Must be symmetric and nonnegative definite
 - `A::ScalarOrArray` : `n x n` coefficient on state in state transition
 - `B::ScalarOrArray` : `n x k` coefficient on control in state transition
 - `C::ScalarOrArray` : `n x j` coefficient on random shock in state transition
 - `N::ScalarOrArray` : `k x n` cross product in payoff equation
 - `bet::Real` : Discount factor in `[0, 1]`
 - `capT::Union{Int, Void}` : Terminal period in finite horizon problem
-- `rf::ScalarOrArray` : n x n terminal payoff in finite horizon problem. Must be symmetric and nonnegative definite
+- `rf::ScalarOrArray` : `n x n` terminal payoff in finite horizon problem. Must be symmetric and nonnegative definite
 - `P::ScalarOrArray` : `n x n` matrix in value function representation ``V(x) = x'Px + d``
 - `d::Real` : Constant in value function representation
 - `F::ScalarOrArray` : Policy rule that specifies optimal control in each period
@@ -98,20 +98,20 @@ transition equation.
 ##### Arguments
 
 - `Q::ScalarOrArray` : `k x k` payoff coefficient for control variable u. Must be
-symmetric and nonnegative definite
+  symmetric and nonnegative definite
 - `R::ScalarOrArray` : `n x n` payoff coefficient matrix for state variable x.
-Must be symmetric and nonnegative definite
+  Must be symmetric and nonnegative definite
 - `A::ScalarOrArray` : `n x n` coefficient on state in state transition
 - `B::ScalarOrArray` : `n x k` coefficient on control in state transition
 - `;C::ScalarOrArray{zeros(size(R}(1)))` : `n x j` coefficient on random shock in
-state transition
+  state transition
 - `;N::ScalarOrArray{zeros(size(B,1)}(size(A, 2)))` : `k x n` cross product in
-payoff equation
+  payoff equation
 - `;bet::Real(1.0)` : Discount factor in `[0, 1]`
 - `capT::Union{Int, Void}(Void)` : Terminal period in finite horizon
-problem
+  problem
 - `rf::ScalarOrArray{fill(NaN}(size(R)...))` : `n x n` terminal payoff in finite
-horizon problem. Must be symmetric and nonnegative definite.
+  horizon problem. Must be symmetric and nonnegative definite.
 
 """
 function LQ(Q::ScalarOrArray,
@@ -133,7 +133,7 @@ function LQ(Q::ScalarOrArray,
     LQ(Q, R, A, B, C, N, bet, capT, rf, P, d, F)
 end
 
-"""
+doc"""
 Update `P` and `d` from the value function representation in finite horizon case
 
 ##### Arguments
@@ -143,7 +143,7 @@ Update `P` and `d` from the value function representation in finite horizon case
 ##### Returns
 
 - `P::ScalarOrArray` : `n x n` matrix in value function representation
-V(x) = x'Px + d
+  ``V(x) = x'Px + d``
 - `d::Real` : Constant in value function representation
 
 ##### Notes
@@ -175,7 +175,7 @@ function update_values!(lq::LQ)
 end
 
 doc"""
-Computes value and policy functions in infinite horizon model
+Computes value and policy functions in infinite horizon model.
 
 ##### Arguments
 

--- a/src/lqcontrol.jl
+++ b/src/lqcontrol.jl
@@ -66,10 +66,8 @@ Must be symmetric and nonnegative definite
 - `N::ScalarOrArray` : `k x n` cross product in payoff equation
 - `bet::Real` : Discount factor in `[0, 1]`
 - `capT::Union{Int, Void}` : Terminal period in finite horizon problem
-- `rf::ScalarOrArray` : n x n terminal payoff in finite horizon problem. Must be
-symmetric and nonnegative definite
-- `P::ScalarOrArray` : `n x n` matrix in value function representation
-V(x) = x'Px + d
+- `rf::ScalarOrArray` : n x n terminal payoff in finite horizon problem. Must be symmetric and nonnegative definite
+- `P::ScalarOrArray` : `n x n` matrix in value function representation ``V(x) = x'Px + d``
 - `d::Real` : Constant in value function representation
 - `F::ScalarOrArray` : Policy rule that specifies optimal control in each period
 

--- a/src/lqnash.jl
+++ b/src/lqnash.jl
@@ -33,29 +33,29 @@ double optimal linear regulator problem.
 
 ##### Arguments
 
-- `A` : Corresponds to the above equation, should be of size (n, n)
-- `B1` : As above, size (n, k_1)
-- `B2` : As above, size (n, k_2)
-- `R1` : As above, size (n, n)
-- `R2` : As above, size (n, n)
-- `Q1` : As above, size (k_1, k_1)
-- `Q2` : As above, size (k_2, k_2)
-- `S1` : As above, size (k_1, k_1)
-- `S2` : As above, size (k_2, k_2)
-- `W1` : As above, size (n, k_1)
-- `W2` : As above, size (n, k_2)
-- `M1` : As above, size (k_2, k_1)
-- `M2` : As above, size (k_1, k_2)
+- `A` : Corresponds to the above equation, should be of size `(n, n)`
+- `B1` : As above, size `(n, k_1)`
+- `B2` : As above, size `(n, k_2)`
+- `R1` : As above, size `(n, n)`
+- `R2` : As above, size `(n, n)`
+- `Q1` : As above, size `(k_1, k_1)`
+- `Q2` : As above, size `(k_2, k_2)`
+- `S1` : As above, size `(k_1, k_1)`
+- `S2` : As above, size `(k_2, k_2)`
+- `W1` : As above, size `(n, k_1)`
+- `W2` : As above, size `(n, k_2)`
+- `M1` : As above, size `(k_2, k_1)`
+- `M2` : As above, size `(k_1, k_2)`
 - `;beta::Float64(1.0)` Discount rate
 - `;tol::Float64(1e-8)` : Tolerance level for convergence
 - `;max_iter::Int(1000)` : Maximum number of iterations allowed
 
 ##### Returns
 
-- `F1::Matrix{Float64}`: (k_1, n) matrix representing feedback law for agent 1
-- `F2::Matrix{Float64}`: (k_2, n) matrix representing feedback law for agent 2
-- `P1::Matrix{Float64}`: (n, n) matrix representing the steady-state solution to the associated discrete matrix ticcati equation for agent 1
-- `P2::Matrix{Float64}`: (n, n) matrix representing the steady-state solution to the associated discrete matrix riccati equation for agent 2
+- `F1::Matrix{Float64}`: `(k_1, n)` matrix representing feedback law for agent 1
+- `F2::Matrix{Float64}`: `(k_2, n)` matrix representing feedback law for agent 2
+- `P1::Matrix{Float64}`: `(n, n)` matrix representing the steady-state solution to the associated discrete matrix ticcati equation for agent 1
+- `P2::Matrix{Float64}`: `(n, n)` matrix representing the steady-state solution to the associated discrete matrix riccati equation for agent 2
 
 """
 function nnash(a, b1, b2, r1, r2, q1, q2, s1, s2, w1, w2, m1, m2;

--- a/src/lqnash.jl
+++ b/src/lqnash.jl
@@ -9,22 +9,26 @@ problems.
 
 =#
 
-"""
+doc"""
 Compute the limit of a Nash linear quadratic dynamic game.
 
 Player `i` minimizes
 
-    sum_{t=1}^{inf}(x_t' r_i x_t + 2 x_t' w_i
+```math
+    \sum_{t=1}^{\infty}(x_t' r_i x_t + 2 x_t' w_i
     u_{it} +u_{it}' q_i u_{it} + u_{jt}' s_i u_{jt} + 2 u_{jt}'
     m_i u_{it})
+```
 
 subject to the law of motion
 
+```math
     x_{t+1} = A x_t + b_1 u_{1t} + b_2 u_{2t}
+```
 
-and a perceived control law :math:`u_j(t) = - f_j x_t` for the other player.
+and a perceived control law ``u_j(t) = - f_j x_t`` for the other player.
 
-The solution computed in this routine is the `f_i` and `p_i` of the associated
+The solution computed in this routine is the ``f_i`` and ``p_i`` of the associated
 double optimal linear regulator problem.
 
 ##### Arguments

--- a/src/lss.jl
+++ b/src/lss.jl
@@ -187,7 +187,7 @@ initial conditions `lss.mu_0` and `lss.Sigma_0`
 #### Returns
 
 - `mu_x::Vector` Represents the stationary mean of ``x_t``
-- `mu_y::Vector`Represents the stationary mean of ``y_t``
+- `mu_y::Vector` Represents the stationary mean of ``y_t``
 - `Sigma_x::Matrix` Represents the var-cov matrix
 - `Sigma_y::Matrix` Represents the var-cov matrix
 

--- a/src/lss.jl
+++ b/src/lss.jl
@@ -26,9 +26,8 @@ A type that describes the Gaussian Linear State Space Model
 of the form:
 
 ```math
-    x_{t+1} = A x_t + C w_{t+1}
-```
-```math
+    x_{t+1} = A x_t + C w_{t+1} \\
+    
     y_t = G x_t + H v_t
 ```
 
@@ -119,9 +118,9 @@ Simulate `num_reps` observations of ``x_T`` and ``y_T`` given ``x_0 \sim N(\mu_0
 
 #### Returns
 
-- `x::Matrix` An n x num_reps matrix, where the j-th column is the j_th
+- `x::Matrix` An `n x num_reps` matrix, where the j-th column is the j_th
               observation of ``x_T``
-- `y::Matrix` An k x num_reps matrix, where the j-th column is the j_th
+- `y::Matrix` An `k x num_reps` matrix, where the j-th column is the j_th
               observation of ``y_T``
 
 """

--- a/src/lss.jl
+++ b/src/lss.jl
@@ -17,21 +17,24 @@ References
 TODO: Come back and update to match `LinearStateSpace` type from py side
 TODO: Add docstrings
 
-http://quant-econ.net/jl/linear_models.html
+https://lectures.quantecon.org/jl/kalman.html
 
 =#
 
-"""
+doc"""
 A type that describes the Gaussian Linear State Space Model
 of the form:
 
+```math
     x_{t+1} = A x_t + C w_{t+1}
+```
+```math
+    y_t = G x_t + H v_t
+```
 
-        y_t = G x_t + H v_t
-
-where {w_t} and {v_t} are independent and standard normal with dimensions
-k and l respectively.  The initial conditions are mu_0 and Sigma_0 for x_0
-~ N(mu_0, Sigma_0).  When Sigma_0=0, the draw of x_0 is exactly mu_0.
+where ``{w_t}`` and ``{v_t}`` are independent and standard normal with dimensions
+`k` and `l` respectively.  The initial conditions are ``\mu_0`` and ``\Sigma_0`` for ``x_0
+\sim N(\mu_0, \Sigma_0)``. When ``\Sigma_0=0``, the draw of ``x_0`` is exactly ``\mu_0``.
 
 #### Fields
 
@@ -105,8 +108,8 @@ function simulate(lss::LSS, ts_length=100)
     return x, y
 end
 
-"""
-Simulate num_reps observations of x_T and y_T given x_0 ~ N(mu_0, Sigma_0).
+doc"""
+Simulate `num_reps` observations of ``x_T`` and ``y_T`` given ``x_0 \sim N(\mu_0, \Sigma_0)``.
 
 #### Arguments
 
@@ -117,9 +120,9 @@ Simulate num_reps observations of x_T and y_T given x_0 ~ N(mu_0, Sigma_0).
 #### Returns
 
 - `x::Matrix` An n x num_reps matrix, where the j-th column is the j_th
-              observation of x_T
+              observation of ``x_T``
 - `y::Matrix` An k x num_reps matrix, where the j-th column is the j_th
-              observation of y_T
+              observation of ``y_T``
 
 """
 function replicate(lss::LSS, t::Integer, num_reps::Integer=100)
@@ -156,11 +159,11 @@ function Base.next(L::LSSMoments, moms)
     (mu_x, mu_y, Sigma_x, Sigma_y), (mu_x2, Sigma_x2)
 end
 
-"""
+doc"""
 Create an iterator to calculate the population mean and
-variance-convariance matrix for both x_t and y_t, starting at
-the initial condition (self.mu_0, self.Sigma_0).  Each iteration
-produces a 4-tuple of items (mu_x, mu_y, Sigma_x, Sigma_y) for
+variance-convariance matrix for both ``x_t`` and ``y_t``, starting at
+the initial condition `(self.mu_0, self.Sigma_0)`.  Each iteration
+produces a 4-tuple of items `(mu_x, mu_y, Sigma_x, Sigma_y)` for
 the next period.
 
 #### Arguments
@@ -171,10 +174,10 @@ the next period.
 moment_sequence(lss::LSS) = LSSMoments(lss)
 
 
-"""
-Compute the moments of the stationary distributions of x_t and
-y_t if possible.  Computation is by iteration, starting from the
-initial conditions lss.mu_0 and lss.Sigma_0
+doc"""
+Compute the moments of the stationary distributions of ``x_t`` and
+``y_t`` if possible.  Computation is by iteration, starting from the
+initial conditions `lss.mu_0` and `lss.Sigma_0`
 
 #### Arguments
 
@@ -184,8 +187,8 @@ initial conditions lss.mu_0 and lss.Sigma_0
 
 #### Returns
 
-- `mu_x::Vector` Represents the stationary mean of x_t
-- `mu_y::Vector`Represents the stationary mean of y_t
+- `mu_x::Vector` Represents the stationary mean of ``x_t``
+- `mu_y::Vector`Represents the stationary mean of ``y_t``
 - `Sigma_x::Matrix` Represents the var-cov matrix
 - `Sigma_y::Matrix` Represents the var-cov matrix
 

--- a/src/markov/ddp.jl
+++ b/src/markov/ddp.jl
@@ -222,7 +222,7 @@ This refers to the Value Iteration solution algorithm.
 References
 ----------
 
-http://quant-econ.net/jl/ddp.html
+https://lectures.quantecon.org/py/discrete_dp.html
 
 """
 immutable VFI <: DDPAlgorithm end
@@ -233,7 +233,7 @@ This refers to the Policy Iteration solution algorithm.
 References
 ----------
 
-http://quant-econ.net/jl/ddp.html
+https://lectures.quantecon.org/py/discrete_dp.html
 
 """
 immutable PFI <: DDPAlgorithm end
@@ -244,7 +244,7 @@ This refers to the Modified Policy Iteration solution algorithm.
 References
 ----------
 
-http://quant-econ.net/jl/ddp.html
+https://lectures.quantecon.org/py/discrete_dp.html
 
 """
 immutable MPFI <: DDPAlgorithm end

--- a/src/markov/ddp.jl
+++ b/src/markov/ddp.jl
@@ -8,7 +8,7 @@ Discrete Decision Processes
 References
 ----------
 
-http://quant-econ.net/jl/ddp.html
+https://lectures.quantecon.org/py/discrete_dp.html
 
 Notes
 -----

--- a/src/markov/ddp.jl
+++ b/src/markov/ddp.jl
@@ -296,9 +296,9 @@ end
 # Bellman operator methods #
 # ------------------------ #
 
-"""
-The Bellman operator, which computes and returns the updated value function Tv
-for a value function v.
+doc"""
+The Bellman operator, which computes and returns the updated value function ``Tv``
+for a value function ``v``.
 
 ##### Parameters
 
@@ -320,7 +320,7 @@ function bellman_operator!(ddp::DiscreteDP, v::Vector, Tv::Vector, sigma::Vector
     Tv, sigma
 end
 
-"""
+doc"""
 Apply the Bellman operator using `v=ddpr.v`, `Tv=ddpr.Tv`, and `sigma=ddpr.sigma`
 
 ##### Notes
@@ -332,8 +332,8 @@ bellman_operator!(ddp::DiscreteDP, ddpr::DPSolveResult) =
     bellman_operator!(ddp, ddpr.v, ddpr.Tv, ddpr.sigma)
 
 """
-The Bellman operator, which computes and returns the updated value function Tv
-for a given value function v.
+The Bellman operator, which computes and returns the updated value function ``Tv``
+for a given value function ``v``.
 
 This function will fill the input `v` with `Tv` and the input `sigma` with the
 corresponding policy rule
@@ -362,9 +362,9 @@ function bellman_operator!{T1<:Rational,T2<:Rational,NR,NQ,T3<:Rational}(ddp::Di
     bellman_operator!(ddp, v, v, sigma)
 end
 
-"""
-The Bellman operator, which computes and returns the updated value function Tv
-for a given value function v.
+doc"""
+The Bellman operator, which computes and returns the updated value function ``Tv``
+for a given value function ``v``.
 
 ##### Parameters
 
@@ -402,8 +402,8 @@ modifies ddpr.sigma and ddpr.Tv in place
 compute_greedy!(ddp::DiscreteDP, ddpr::DPSolveResult) =
     (bellman_operator!(ddp, ddpr); ddpr.sigma)
 
-"""
-Compute the v-greedy policy.
+doc"""
+Compute the ``v``-greedy policy.
 
 #### Arguments
 
@@ -444,7 +444,7 @@ Compute the value of a policy.
 
 ##### Returns
 
-- `v_sigma::Array{Float64}` : Value vector of `sigma`, of length n.
+- `v_sigma::Array{Float64}` : Value vector of `sigma`, of length `n`.
 
 """
 function evaluate_policy{T<:Integer}(ddp::DiscreteDP, sigma::Vector{T})

--- a/src/markov/ddp.jl
+++ b/src/markov/ddp.jl
@@ -250,7 +250,7 @@ https://lectures.quantecon.org/py/discrete_dp.html
 immutable MPFI <: DDPAlgorithm end
 
 """
-DPSolveResult is an object for retaining results and associated metadata after
+`DPSolveResult` is an object for retaining results and associated metadata after
 solving the model
 
 ##### Parameters
@@ -259,7 +259,7 @@ solving the model
 
 ##### Returns
 
-- `ddpr::DPSolveResult` : DiscreteDP Results object
+- `ddpr::DPSolveResult` : DiscreteDP results object
 
 """
 type DPSolveResult{Algo<:DDPAlgorithm,Tval<:Real}
@@ -336,7 +336,7 @@ The Bellman operator, which computes and returns the updated value function ``Tv
 for a given value function ``v``.
 
 This function will fill the input `v` with `Tv` and the input `sigma` with the
-corresponding policy rule
+corresponding policy rule.
 
 ##### Parameters
 
@@ -382,8 +382,8 @@ bellman_operator(ddp::DiscreteDP, v::Vector) =
 # Compute greedy methods #
 # ---------------------- #
 
-"""
-Compute the v-greedy policy
+doc"""
+Compute the ``v``-greedy policy
 
 ##### Parameters
 
@@ -465,18 +465,18 @@ Solve the dynamic programming problem.
 
 - `ddp::DiscreteDP` : Object that contains the Model Parameters
 - `method::Type{T<Algo}(VFI)`: Type name specifying solution method. Acceptable
-arguments are `VFI` for value function iteration or `PFI` for policy function
-iteration or `MPFI` for modified policy function iteration
+  arguments are `VFI` for value function iteration or `PFI` for policy function
+  iteration or `MPFI` for modified policy function iteration
 - `;max_iter::Int(250)` : Maximum number of iterations
 - `;epsilon::Float64(1e-3)` : Value for epsilon-optimality. Only used if
-`method` is `VFI`
+  `method` is `VFI`
 - `;k::Int(20)` : Number of iterations for partial policy evaluation in modified
-policy iteration (irrelevant for other methods).
+  policy iteration (irrelevant for other methods).
 
 ##### Returns
 
 - `ddpr::DPSolveResult{Algo}` : Optimization result represented as a
-DPSolveResult. See `DPSolveResult` for details.
+  `DPSolveResult`. See `DPSolveResult` for details.
 """
 function solve{Algo<:DDPAlgorithm,T}(ddp::DiscreteDP{T}, method::Type{Algo}=VFI;
                                      max_iter::Integer=250, epsilon::Real=1e-3,
@@ -534,10 +534,10 @@ the transition probability matrix `Q_sigma`.
 
 ##### Returns
 
-- `R_sigma::Array{Float64}`: Reward vector for `sigma`, of length n.
+- `R_sigma::Array{Float64}`: Reward vector for `sigma`, of length `n`.
 
 - `Q_sigma::Array{Float64}`: Transition probability matrix for `sigma`,
-  of shape (n, n).
+  of shape `(n, n)`.
 
 """
 function RQ_sigma{T<:Integer}(ddp::DDP, sigma::Array{T})
@@ -582,7 +582,7 @@ s_wise_max!(vals::AbstractMatrix, out::Vector) = (println("calling this one! ");
 Populate `out` with  `max_a vals(s, a)`,  where `vals` is represented as a
 `AbstractMatrix` of size `(num_states, num_actions)`.
 
-Also fills `out_argmax` with the column number associated with the indmax in
+Also fills `out_argmax` with the column number associated with the `indmax` in
 each row
 """
 function s_wise_max!(vals::AbstractMatrix, out::Vector, out_argmax::Vector)
@@ -642,7 +642,7 @@ end
 Populate `out` with  `max_a vals(s, a)`,  where `vals` is represented as a
 `Vector` of size `(num_sa_pairs,)`.
 
-Also fills `out_argmax` with the cartesiean index associated with the indmax in
+Also fills `out_argmax` with the cartesiean index associated with the `indmax` in
 each row
 """
 function s_wise_max!(a_indices::Vector, a_indptr::Vector, vals::Vector,
@@ -669,7 +669,7 @@ Check whether `s_indices` and `a_indices` are sorted in lexicographic order.
 
 Parameters
 ----------
-s_indices, a_indices : Vectors
+`s_indices`, `a_indices` : Vectors
 
 Returns
 -------
@@ -696,11 +696,10 @@ in sorted order.
 
 Parameters
 ----------
-num_states : Int
+- `num_states::Integer`
+- `s_indices::Vector{T}`
+- `out::Vector{T}` :  with length = `num_states` + 1
 
-s_indices : Vector{Int}
-
-out : Vector{Int} with length = num_states+1
 """
 function _generate_a_indptr!(num_states::Int, s_indices::Vector, out::Vector)
     idx = 1
@@ -727,10 +726,10 @@ function _find_indices!(a_indices::Vector, a_indptr::Vector, sigma::Vector,
     end
 end
 
-"""
+doc"""
 Define Matrix Multiplication between 3-dimensional matrix and a vector
 
-Matrix multiplication over the last dimension of A
+Matrix multiplication over the last dimension of ``A``
 
 """
 function *{T}(A::Array{T,3}, v::Vector)

--- a/src/markov/markov_approx.jl
+++ b/src/markov/markov_approx.jl
@@ -32,7 +32,7 @@ where ``\epsilon_t \sim N (0, \sigma^2)``
 - `σ::Real` : Standard deviation of random component of AR(1) process
 - `μ::Real(0.0)` : Mean of AR(1) process
 - `n_std::Integer(3)` : The number of standard deviations to each side the process
-should span
+  should span
 
 ##### Returns
 
@@ -175,7 +175,7 @@ For more info, refer to:
 ##### Returns
 
 - `mc::MarkovChain{T}` : A Markov chain holding the state values and
-transition matrix
+  transition matrix
 
 """
 function estimate_mc_discrete{T}(X::Vector{T}, states::Vector{T})

--- a/src/markov/markov_approx.jl
+++ b/src/markov/markov_approx.jl
@@ -8,20 +8,22 @@ Various routines to discretize AR(1) processes
 References
 ----------
 
-http://quant-econ.net/jl/finite_markov.html
+https://lectures.quantecon.org/jl/finite_markov.html
 =#
 
 std_norm_cdf{T <: Real}(x::T) = 0.5 * erfc(-x/sqrt(2))
 std_norm_cdf{T <: Real}(x::Array{T}) = 0.5 .* erfc(-x./sqrt(2))
 
-"""
+doc"""
 Tauchen's (1996) method for approximating AR(1) process with finite markov chain
 
 The process follows
 
-    y_t = μ + ρ y_{t-1} + ε_t,
+```math
+    y_t = \mu + \rho y_{t-1} + \epsilon_t
+```
 
-where ε_t ~ N (0, σ^2)
+where ``\epsilon_t \sim N (0, \sigma^2)``
 
 ##### Arguments
 
@@ -34,8 +36,7 @@ should span
 
 ##### Returns
 
-- `mc::MarkovChain{Float64}` : Markov chain holding the state values and
-transition matrix
+- `mc::MarkovChain{Float64}` : Markov chain holding the state values and transition matrix
 
 """
 function tauchen(N::Integer, ρ::Real, σ::Real, μ::Real=0.0, n_std::Integer=3)
@@ -83,14 +84,16 @@ function tauchen(N::Integer, ρ::Real, σ::Real, μ::Real=0.0, n_std::Integer=3)
 end
 
 
-"""
+doc"""
 Rouwenhorst's method to approximate AR(1) processes.
 
 The process follows
 
-    y_t = μ + ρ y_{t-1} + ε_t,
+```math
+    y_t = \mu + \rho y_{t-1} + \epsilon_t
+```
 
-where ε_t ~ N (0, σ^2)
+where ``\epsilon_t \sim N (0, \sigma^2)``
 
 ##### Arguments
 - `N::Integer` : Number of points in markov process
@@ -100,8 +103,7 @@ where ε_t ~ N (0, σ^2)
 
 ##### Returns
 
-- `mc::MarkovChain{Float64}` : Markov chain holding the state values and
-transition matrix
+- `mc::MarkovChain{Float64}` : Markov chain holding the state values and transition matrix
 
 """
 function rouwenhorst(N::Integer, ρ::Real, σ::Real, μ::Real=0.0)
@@ -136,24 +138,26 @@ end
 @inline _emcd_lt{T}(a::T, b::T) = isless(a, b)
 @inline _emcd_lt{T}(a::Vector{T}, b::Vector{T}) = Base.lt(Base.Order.Lexicographic, a, b)
 
-"""
+doc"""
 Accepts the simulation of a discrete state Markov chain and estimates
 the transition probabilities
 
-Let S = {s₁, s₂, ..., sₙ} with s₁ < s₂ < ... < sₙ be the discrete
-states of a Markov chain. Furthermore, let P be the corresponding
+Let ``S = s_1, s_2, \ldots, s_i`` with ``s_1 < s_2 < \ldots < s_i`` be the discrete
+states of a Markov chain. Furthermore, let ``P`` be the corresponding
 stochastic transition matrix.
 
-Given a history of observations, {X} where xₜ ∈ S ∀ t, we would like
-to estimate the transition probabilities in P, pᵢⱼ. For xₜ=sᵢ and xₜ₋₁=sⱼ,
-let P(xₜ | xₜ₋₁) be the pᵢⱼ element of the stochastic matrix. The likelihood
+Given a history of observations, ``{X}`` where ``x_t \in S \forall t``, we would like
+to estimate the transition probabilities in ``P``, ``p_{i,j}``. For ``x_t=s_i`` and ``x_{t-1}=s_j``,
+let ``P(x_t | x_{t-1})`` be the ``p_{i,j}`` element of the stochastic matrix. The likelihood
 function is then given by
 
-    L({X}ₜ; P) = P(x_1) ∏_{t=2}^{T} P(xₜ | xₜ₋₁)
+```math
+    L({X}_t; P) = P(x_1) \prod_{t=2}^{T} P(x_t | x_{t-1})
+```
 
 The maximum likelihood estimate is then just given by the number of times
-a transition from sᵢ to sⱼ is observed divided by the number of times
-sᵢ was observed.
+a transition from ``s_i`` to ``s_j`` is observed divided by the number of times
+``s_i`` was observed.
 
 Note: Because of the estimation procedure used, only states that are observed
 in the history appear in the estimated Markov chain... It can't divine whether

--- a/src/markov/markov_approx.jl
+++ b/src/markov/markov_approx.jl
@@ -142,17 +142,18 @@ doc"""
 Accepts the simulation of a discrete state Markov chain and estimates
 the transition probabilities
 
-Let ``S = s_1, s_2, \ldots, s_i`` with ``s_1 < s_2 < \ldots < s_i`` be the discrete
+Let ``S = s_1, s_2, \ldots, s_N`` with ``s_1 < s_2 < \ldots < s_N`` be the discrete
 states of a Markov chain. Furthermore, let ``P`` be the corresponding
 stochastic transition matrix.
 
-Given a history of observations, ``{X}`` where ``x_t \in S \forall t``, we would like
-to estimate the transition probabilities in ``P``, ``p_{i,j}``. For ``x_t=s_i`` and ``x_{t-1}=s_j``,
-let ``P(x_t | x_{t-1})`` be the ``p_{i,j}`` element of the stochastic matrix. The likelihood
-function is then given by
+Given a history of observations, ``\{X\}_{t=0}^{T}`` with ``x_t \in S \forall t``,
+we would like to estimate the transition probabilities in ``P`` with ``p_{ij}``
+as the ith row and jth column of ``P``. For ``x_t = s_i`` and ``x_{t-1} = s_j``,
+let ``P(x_t | x_{t-1})`` be defined as ``p_{i,j}`` element of the stochastic
+matrix. The likelihood function is then given by
 
 ```math
-    L({X}_t; P) = P(x_1) \prod_{t=2}^{T} P(x_t | x_{t-1})
+  L(\{X\}^t; P) = \text{Prob}(x_1) \prod_{t=2}^{T} P(x_t | x_{t-1})
 ```
 
 The maximum likelihood estimate is then just given by the number of times

--- a/src/markov/mc_tools.jl
+++ b/src/markov/mc_tools.jl
@@ -82,7 +82,7 @@ one, up to normalization) nonzero solution exists corresponding to each
 reccurent class of ``A``, and in particular, if ``A`` is irreducible, there is a
 unique solution; when there are more than one solution, the routine returns the
 solution that contains in its support the first index ``i`` such that no path
-connects `i` to any index larger than ``i``. The solution is normalized so that
+connects ``i`` to any index larger than ``i``. The solution is normalized so that
 its 1-norm equals one. This routine implements the Grassmann-Taksar-Heyman
 (GTH) algorithm (Grassmann, Taksar, and Heyman 1985), a numerically stable
 variant of Gaussian elimination, where only the off-diagonal entries of ``A`` are
@@ -101,10 +101,10 @@ used as the input data. For a nice exposition of the algorithm, see Stewart
 ##### References
 
 - W. K. Grassmann, M. I. Taksar and D. P. Heyman, "Regenerative Analysis and
-Steady State Distributions for Markov Chains, " Operations Research (1985),
-1107-1116.
+  Steady State Distributions for Markov Chains, " Operations Research (1985),
+  1107-1116.
 - W. J. Stewart, Probability, Markov Chains, Queues, and Simulation, Princeton
-University Press, 2009.
+  University Press, 2009.
 
 """
 gth_solve{T<:Real}(A::Matrix{T}) = gth_solve!(copy(A))
@@ -159,7 +159,7 @@ Find the recurrent classes of the Markov chain `mc`.
 ##### Returns
 
 - `::Vector{Vector{Int}}` : Vector of vectors that describe the recurrent
-classes of `mc`.
+  classes of `mc`.
 
 """
 recurrent_classes(mc::MarkovChain) = attracting_components(DiGraph(mc.p))
@@ -174,7 +174,7 @@ Find the communication classes of the Markov chain `mc`.
 ### Returns
 
 - `::Vector{Vector{Int}}` : Vector of vectors that describe the communication
-classes of `mc`.
+  classes of `mc`.
 
 """
 communication_classes(mc::MarkovChain) = strongly_connected_components(DiGraph(mc.p))
@@ -273,7 +273,7 @@ recurrent class.
 """ stationary_distributions
 
 
-"""Custom version of `full`, which allows convertion to type T"""
+"""Custom version of `full`, which allows convertion to type `T`"""
 # From base/sparse/sparsematrix.jl
 function todense(T::Type, S::SparseMatrixCSC)
     A = zeros(T, S.m, S.n)
@@ -287,7 +287,7 @@ function todense(T::Type, S::SparseMatrixCSC)
     return A
 end
 
-"""If A is already dense, return A as is"""
+"""If `A` is already dense, return `A` as is"""
 todense(::Type, A::Array) = A
 
 
@@ -356,7 +356,7 @@ The resulting vector has the state values of `mc` as elements.
 ### Returns
 
 - `X::Vector` : Vector containing the sample path, with length
-ts_length
+  ts_length
 """
 function simulate(mc::MarkovChain, ts_length::Int;
                   init::Int=rand(1:n_states(mc)))
@@ -411,7 +411,7 @@ The resulting vector has the indices of the state values of `mc` as elements.
 ### Returns
 
 - `X::Vector{Int}` : Vector containing the sample path, with length
-ts_length
+  ts_length
 """
 function simulate_indices(mc::MarkovChain, ts_length::Int;
                           init::Int=rand(1:n_states(mc)))

--- a/src/markov/mc_tools.jl
+++ b/src/markov/mc_tools.jl
@@ -8,7 +8,8 @@ Tools for working with Markov Chains
 References
 ----------
 
-http://quant-econ.net/jl/finite_markov.html
+https://lectures.quantecon.org/jl/finite_markov.html
+
 =#
 import LightGraphs: DiGraph, period, attracting_components,
                     strongly_connected_components, is_strongly_connected
@@ -70,23 +71,23 @@ function Base.show{T,TM}(io::IO, mc::MarkovChain{T,TM})
     print(io, mc.p)
 end
 
-"""
+doc"""
 This routine computes the stationary distribution of an irreducible Markov
 transition matrix (stochastic matrix) or transition rate matrix (generator
-matrix) `A`.
+matrix) ``A``.
 
 More generally, given a Metzler matrix (square matrix whose off-diagonal
-entries are all nonnegative) `A`, this routine solves for a nonzero solution
-`x` to `x (A - D) = 0`, where `D` is the diagonal matrix for which the rows of
-`A - D` sum to zero (i.e., `D_{ii} = \sum_j A_{ij}` for all `i`). One (and only
+entries are all nonnegative) ``A``, this routine solves for a nonzero solution
+``x`` to ``x (A - D) = 0``, where ``D`` is the diagonal matrix for which the rows of
+``A - D`` sum to zero (i.e., ``D_{ii} = \sum_j A_{ij}`` for all ``i``). One (and only
 one, up to normalization) nonzero solution exists corresponding to each
-reccurent class of `A`, and in particular, if `A` is irreducible, there is a
+reccurent class of ``A``, and in particular, if ``A`` is irreducible, there is a
 unique solution; when there are more than one solution, the routine returns the
-solution that contains in its support the first index `i` such that no path
-connects `i` to any index larger than `i`. The solution is normalized so that
+solution that contains in its support the first index ``i`` such that no path
+connects `i` to any index larger than ``i``. The solution is normalized so that
 its 1-norm equals one. This routine implements the Grassmann-Taksar-Heyman
 (GTH) algorithm (Grassmann, Taksar, and Heyman 1985), a numerically stable
-variant of Gaussian elimination, where only the off-diagonal entries of `A` are
+variant of Gaussian elimination, where only the off-diagonal entries of ``A`` are
 used as the input data. For a nice exposition of the algorithm, see Stewart
 (2009), Chapter 10.
 
@@ -97,7 +98,7 @@ used as the input data. For a nice exposition of the algorithm, see Stewart
 
 ##### Returns
 
-- `x::Vector{T}` : Stationary distribution of `A`.
+- `x::Vector{T}` : Stationary distribution of ``A``.
 
 ##### References
 

--- a/src/markov/mc_tools.jl
+++ b/src/markov/mc_tools.jl
@@ -25,10 +25,8 @@ state transitions.
 
 ##### Fields
 
-- `p::AbstractMatrix` : The transition matrix. Must be square, all elements
-must be nonnegative, and all rows must sum to unity.
-- `state_values::AbstractVector` : Vector containing the values associated with
-the states.
+- `p::AbstractMatrix` : The transition matrix. Must be square, all elements must be nonnegative, and all rows must sum to unity.
+- `state_values::AbstractVector` : Vector containing the values associated with the states.
 """
 type MarkovChain{T, TM<:AbstractMatrix, TV<:AbstractVector}
     p::TM # valid stochastic matrix

--- a/src/markov/random_mc.jl
+++ b/src/markov/random_mc.jl
@@ -88,7 +88,7 @@ each row.
 
 - `n::Integer` : Number of states.
 - `k::Union{Integer, Void}(nothing)` : Number of nonzero entries in each
-column of the matrix. Set to `n` if note specified.
+  column of the matrix. Set to `n` if none specified.
 
 ##### Returns
 
@@ -118,12 +118,12 @@ as columns `m` probability vectors of length `n` with `k` nonzero entries.
 - `n::Integer` : Number of states.
 - `m::Integer` : Number of probability vectors.
 - `;k::Union{Integer, Void}(nothing)` : Number of nonzero entries in each
-column of the matrix. Set to `n` if note specified.
+  column of the matrix. Set to `n` if none specified.
 
 ##### Returns
 
 - `p::Array` : Array of shape `(n, m)` containing `m` probability vectors of length
-`n` as columns.
+  `n` as columns.
 
 """
 function _random_stochastic_matrix(n::Integer, m::Integer;
@@ -164,11 +164,11 @@ distribution with mean 0 and standard deviation `scale`.
 - `num_states::Integer` : Number of states.
 - `num_actions::Integer` : Number of actions.
 - `beta::Union{Float64, Void}(nothing)` : Discount factor. Randomly chosen from
-[0, 1) if not specified.
+  `[0, 1)` if not specified.
 - `;k::Union{Integer, Void}(nothing)` : Number of possible next states for each
-state-action pair. Equal to `num_states` if not specified.
+  state-action pair. Equal to `num_states` if not specified.
 - `scale::Real(1)` : Standard deviation of the normal distribution for the
-reward values.
+  reward values.
 
 ##### Returns
 

--- a/src/markov/random_mc.jl
+++ b/src/markov/random_mc.jl
@@ -10,7 +10,7 @@ import QuantEcon: MarkovChain, DiscreteDP
 # random_markov_chain
 
 """
-Return a randomly sampled MarkovChain instance with n states.
+Return a randomly sampled MarkovChain instance with `n` states.
 
 ##### Arguments
 
@@ -44,8 +44,8 @@ end
 
 
 """
-Return a randomly sampled MarkovChain instance with n states, where each state
-has k states with positive transition probability.
+Return a randomly sampled MarkovChain instance with `n` states, where each state
+has `k` states with positive transition probability.
 
 ##### Arguments
 
@@ -81,14 +81,14 @@ end
 # random_stochastic_matrix
 
 """
-Return a randomly sampled n x n stochastic matrix with k nonzero entries for
+Return a randomly sampled `n x n` stochastic matrix with `k` nonzero entries for
 each row.
 
 ##### Arguments
 
 - `n::Integer` : Number of states.
 - `k::Union{Integer, Void}(nothing)` : Number of nonzero entries in each
-column of the matrix. Set to n if note specified.
+column of the matrix. Set to `n` if note specified.
 
 ##### Returns
 
@@ -110,20 +110,20 @@ end
 
 
 """
-Generate a "non-square column stochstic matrix" of shape (n, m), which contains
-as columns m probability vectors of length n with k nonzero entries.
+Generate a "non-square column stochstic matrix" of shape `(n, m)`, which contains
+as columns `m` probability vectors of length `n` with `k` nonzero entries.
 
 ##### Arguments
 
 - `n::Integer` : Number of states.
 - `m::Integer` : Number of probability vectors.
 - `;k::Union{Integer, Void}(nothing)` : Number of nonzero entries in each
-column of the matrix. Set to n if note specified.
+column of the matrix. Set to `n` if note specified.
 
 ##### Returns
 
-- `p::Array` : Array of shape (n, m) containing m probability vectors of length
-n as columns.
+- `p::Array` : Array of shape `(n, m)` containing `m` probability vectors of length
+`n` as columns.
 
 """
 function _random_stochastic_matrix(n::Integer, m::Integer;
@@ -167,7 +167,6 @@ distribution with mean 0 and standard deviation `scale`.
 [0, 1) if not specified.
 - `;k::Union{Integer, Void}(nothing)` : Number of possible next states for each
 state-action pair. Equal to `num_states` if not specified.
-
 - `scale::Real(1)` : Standard deviation of the normal distribution for the
 reward values.
 
@@ -199,7 +198,7 @@ end
 # random_probvec
 
 """
-Return m randomly sampled probability vectors of size k.
+Return `m` randomly sampled probability vectors of size `k`.
 
 ##### Arguments
 
@@ -208,7 +207,7 @@ Return m randomly sampled probability vectors of size k.
 
 ##### Returns
 
-- `a::Array` : Array of shape (k, m) containing probability vectors as colums.
+- `a::Array` : Array of shape `(k, m)` containing probability vectors as columns.
 
 """
 function random_probvec(k::Integer, m::Integer)

--- a/src/matrix_eqn.jl
+++ b/src/matrix_eqn.jl
@@ -1,30 +1,35 @@
 # matrix_eqn.jl
 
-"""
+doc"""
 Solves the discrete lyapunov equation.
 
 The problem is given by
 
+```math
     AXA' - X + B = 0
+```
 
-`X` is computed by using a doubling algorithm. In particular, we iterate to
-convergence on `X_j` with the following recursions for j = 1, 2,...
-starting from X_0 = B, a_0 = A:
+``X`` is computed by using a doubling algorithm. In particular, we iterate to
+convergence on ``X_j`` with the following recursions for ``j = 1, 2, \ldots``
+starting from ``X_0 = B, a_0 = A``:
 
-    a_j = a_{j-1} a_{j-1}
+```math
+    a_j = a_{j-1} a_{j-1} \\
+
     X_j = X_{j-1} + a_{j-1} X_{j-1} a_{j-1}'
+```
 
 ##### Arguments
 
-- `A::Matrix{Float64}` : An n x n matrix as described above.  We assume in order
-for  convergence that the eigenvalues of `A` have moduli bounded by unity
-- `B::Matrix{Float64}` :  An n x n matrix as described above.  We assume in order
-for convergence that the eigenvalues of `B` have moduli bounded by unity
+- `A::Matrix{Float64}` : An `n x n` matrix as described above.  We assume in order
+for  convergence that the eigenvalues of ``A`` have moduli bounded by unity
+- `B::Matrix{Float64}` :  An `n x n` matrix as described above.  We assume in order
+for convergence that the eigenvalues of ``B`` have moduli bounded by unity
 - `max_it::Int(50)` :  Maximum number of iterations
 
 ##### Returns
 
-- `gamma1::Matrix{Float64}` Represents the value X
+- `gamma1::Matrix{Float64}` Represents the value ``X``
 
 """
 function solve_discrete_lyapunov(A::ScalarOrArray,
@@ -60,30 +65,32 @@ function solve_discrete_lyapunov(A::ScalarOrArray,
     return gamma1
 end
 
-"""
+doc"""
 Solves the discrete-time algebraic Riccati equation
 
 The prolem is defined as
 
+```math
     X = A'XA - (N + B'XA)'(B'XB + R)^{-1}(N + B'XA) + Q
+```
 
 via a modified structured doubling algorithm.  An explanation of the algorithm
 can be found in the reference below.
 
 ##### Arguments
 
-- `A` : k x k array.
-- `B` : k x n array
-- `R` : n x n, should be symmetric and positive definite
-- `Q` : k x k, should be symmetric and non-negative definite
-- `N::Matrix{Float64}(zeros(size(R, 1), size(Q, 1)))` : n x k array
+- `A` : `k x k` array.
+- `B` : `k x n` array
+- `R` : `n x n`, should be symmetric and positive definite
+- `Q` : `k x k`, should be symmetric and non-negative definite
+- `N::Matrix{Float64}(zeros(size(R, 1), size(Q, 1)))` : `n x k` array
 - `tolerance::Float64(1e-10)` Tolerance level for convergence
 - `max_iter::Int(50)` : The maximum number of iterations allowed
 
-Note that `A, B, R, Q` can either be real (i.e. k, n = 1) or matrices.
+Note that `A, B, R, Q` can either be real (i.e. `k, n = 1`) or matrices.
 
 ##### Returns
-- `X::Matrix{Float64}` The fixed point of the Riccati equation; a  k x k array
+- `X::Matrix{Float64}` The fixed point of the Riccati equation; a `k x k` array
 representing the approximate solution
 
 ##### References
@@ -169,47 +176,47 @@ function solve_discrete_riccati(A::ScalarOrArray, B::ScalarOrArray,
     return H0 + gamma .* I  # Return X
 end
 
-"""
-Simple method to return an element Z in the Riccati equation solver whose type is Float64 (to be accepted by the cond() function)
+doc"""
+Simple method to return an element ``Z`` in the Riccati equation solver whose type is `Float64` (to be accepted by the `cond()` function)
 
 ##### Arguments
 
-- `BB::Float64` : result of B' * B
+- `BB::Float64` : result of ``B' B``
 - `gamma::Float64` : parameter in the Riccati equation solver
 - `R::Float64`
 
 ##### Returns
-- `::Float64` : element Z in the Riccati equation solver
+- `::Float64` : element ``Z`` in the Riccati equation solver
 
 """
 getZ(R::Float64, gamma::Float64, BB::Float64) = R + gamma * BB
 
-"""
-Simple method to return an element Z in the Riccati equation solver whose type is Float64 (to be accepted by the cond() function)
+doc"""
+Simple method to return an element ``Z`` in the Riccati equation solver whose type is `Float64` (to be accepted by the `cond()` function)
 
 ##### Arguments
 
-- `BB::Union{Vector, Matrix}` : result of B' * B
+- `BB::Union{Vector, Matrix}` : result of ``B' B``
 - `gamma::Float64` : parameter in the Riccati equation solver
 - `R::Float64`
 
 ##### Returns
-- `::Float64` : element Z in the Riccati equation solver
+- `::Float64` : element ``Z`` in the Riccati equation solver
 
 """
 getZ(R::Float64, gamma::Float64, BB::Union{Vector, Matrix}) = R + gamma * BB[1]
 
-"""
-Simple method to return an element Z in the Riccati equation solver whose type is Matrix (to be accepted by the cond() function)
+doc"""
+Simple method to return an element ``Z`` in the Riccati equation solver whose type is Matrix (to be accepted by the `cond()` function)
 
 ##### Arguments
 
-- `BB::Matrix` : result of B' * B
+- `BB::Matrix` : result of ``B' B``
 - `gamma::Float64` : parameter in the Riccati equation solver
 - `R::Matrix`
 
 ##### Returns
-- `::Matrix` : element Z in the Riccati equation solver
+- `::Matrix` : element ``Z`` in the Riccati equation solver
 
 """
 getZ(R::Matrix, gamma::Float64, BB::Matrix) = R + gamma .* BB

--- a/src/matrix_eqn.jl
+++ b/src/matrix_eqn.jl
@@ -22,9 +22,9 @@ starting from ``X_0 = B, a_0 = A``:
 ##### Arguments
 
 - `A::Matrix{Float64}` : An `n x n` matrix as described above.  We assume in order
-for  convergence that the eigenvalues of ``A`` have moduli bounded by unity
+  for  convergence that the eigenvalues of ``A`` have moduli bounded by unity
 - `B::Matrix{Float64}` :  An `n x n` matrix as described above.  We assume in order
-for convergence that the eigenvalues of ``B`` have moduli bounded by unity
+  for convergence that the eigenvalues of ``B`` have moduli bounded by unity
 - `max_it::Int(50)` :  Maximum number of iterations
 
 ##### Returns
@@ -91,7 +91,7 @@ Note that `A, B, R, Q` can either be real (i.e. `k, n = 1`) or matrices.
 
 ##### Returns
 - `X::Matrix{Float64}` The fixed point of the Riccati equation; a `k x k` array
-representing the approximate solution
+  representing the approximate solution
 
 ##### References
 

--- a/src/quad.jl
+++ b/src/quad.jl
@@ -18,7 +18,7 @@ const qnw_func_notes = """
 ##### Notes
 
 If any of the parameters to this function are scalars while others are
-`Vector`s of length `n`, the the scalar parameter is repeated `n` times.
+vectors of length `n`, the the scalar parameter is repeated `n` times.
 """
 
 const qnw_returns = """
@@ -125,14 +125,14 @@ function qnwcheb(n::Int, a::Real, b::Real)
 end
 
 """
-Computes nodes and weights for multivariate normal distribution
+Computes nodes and weights for multivariate normal distribution.
 
 ##### Arguments
 
 - `n::Union{Int, Vector{Int}}` : Number of desired nodes along each dimension
 - `mu::Union{Real, Vector{Real}}` : Mean along each dimension
 - `sig2::Union{Real, Vector{Real}, Matrix{Real}}(eye(length(n)))` : Covariance
-structure
+  structure
 
 $(qnw_returns)
 
@@ -148,7 +148,7 @@ of repeats is inferred from `sig2`.
 the covariance matrix. If it is a vector, it is considered the diagonal of a
 diagonal covariance matrix. If it is a scalar it is repeated along the diagonal
 as many times as necessary, where the number of repeats is determined by the
-length of either n and/or mu (which ever is a vector).
+length of either `n` and/or `mu` (which ever is a vector).
 
 If all 3 are scalars, then 1d nodes are computed. `mu` and `sig2` are treated as
 the mean and variance of a 1d normal distribution
@@ -282,15 +282,15 @@ function qnwtrap(n::Int, a::Real, b::Real)
 end
 
 """
-Computes nodes and weights for beta distribution
+Computes nodes and weights for beta distribution.
 
 ##### Arguments
 
 - `n::Union{Int, Vector{Int}}` : Number of desired nodes along each dimension
 - `a::Union{Real, Vector{Real}}` : First parameter of the beta distribution,
-along each dimension
+  along each dimension
 - `b::Union{Real, Vector{Real}}` : Second parameter of the beta distribution,
-along each dimension
+  along each dimension
 
 $(qnw_returns)
 
@@ -397,9 +397,9 @@ Computes nodes and weights for beta distribution
 
 - `n::Union{Int, Vector{Int}}` : Number of desired nodes along each dimension
 - `a::Union{Real, Vector{Real}}` : Shape parameter of the gamma distribution,
-along each dimension. Must be positive. Default is 1
+  along each dimension. Must be positive. Default is 1
 - `b::Union{Real, Vector{Real}}` : Scale parameter of the gamma distribution,
-along each dimension. Must be positive. Default is 1
+  along each dimension. Must be positive. Default is 1
 
 $(qnw_returns)
 
@@ -598,7 +598,7 @@ qnwnorm(n::Int, mu::Real, sig2::Vector) =
 
 
 """
-Computes quadrature nodes and weights for multivariate uniform distribution
+Computes quadrature nodes and weights for multivariate uniform distribution.
 
 ##### Arguments
 
@@ -626,7 +626,7 @@ Computes quadrature nodes and weights for multivariate uniform distribution
 - `n::Union{Int, Vector{Int}}` : Number of desired nodes along each dimension
 - `mu::Union{Real, Vector{Real}}` : Mean along each dimension
 - `sig2::Union{Real, Vector{Real}, Matrix{Real}}(eye(length(n)))` : Covariance
-structure
+  structure
 
 
 $(qnw_returns)
@@ -742,7 +742,7 @@ Approximate the integral of `f`, given quadrature `nodes` and `weights`
 ##### Arguments
 
 - `f::Function`: A callable function that is to be approximated over the domain
-spanned by `nodes`.
+  spanned by `nodes`.
 - `nodes::Array`: Quadrature nodes
 - `weights::Array`: Quadrature nodes
 - `args...(Void)`: additional positional arguments to pass to `f`
@@ -751,7 +751,7 @@ spanned by `nodes`.
 ##### Returns
 
 - `out::Float64` : The scalar that approximates integral of `f` on the hypercube
-formed by `[a, b]`
+  formed by `[a, b]`
 
 """
 function do_quad(f::Function, nodes::Array, weights::Vector, args...;
@@ -761,20 +761,20 @@ end
 do_quad(f::Function, nodes::Array, weights::Vector) = dot(f(nodes), weights)
 
 """
-Integrate the d-dimensional function f on a rectangle with lower and upper bound
-for dimension i defined by a[i] and b[i], respectively; using n[i] points.
+Integrate the d-dimensional function `f` on a rectangle with lower and upper bound
+for dimension i defined by `a[i]` and `b[i]`, respectively; using `n[i]` points.
 
 ##### Arguments
 
 - `f::Function` The function to integrate over. This should be a function that
-accepts as its first argument a matrix representing points along each dimension
-(each dimension is a column). Other arguments that need to be passed to the
-function are caught by `args...` and `kwargs...``
+  accepts as its first argument a matrix representing points along each dimension
+  (each dimension is a column). Other arguments that need to be passed to the
+  function are caught by `args...` and `kwargs...``
 - `n::Union{Int, Vector{Int}}` : Number of desired nodes along each dimension
 - `a::Union{Real, Vector{Real}}` : Lower endpoint along each dimension
 - `b::Union{Real, Vector{Real}}` : Upper endpoint along each dimension
 - `kind::AbstractString("lege")` Specifies which type of integration to perform. Valid
-values are:
+  values are:
     - `"lege"` : Gauss-Legendre
     - `"cheb"` : Gauss-Chebyshev
     - `"trap"` : trapezoid rule
@@ -789,7 +789,7 @@ values are:
 ##### Returns
 
 - `out::Float64` : The scalar that approximates integral of `f` on the hypercube
-formed by `[a, b]`
+  formed by `[a, b]`
 
 $(qnw_refs)
 

--- a/src/quadsums.jl
+++ b/src/quadsums.jl
@@ -6,36 +6,38 @@ Functions to compute quadratic sums
 @date : 2014-08-19
 =#
 
-"""
+doc"""
 Computes the expected discounted quadratic sum
 
-    q(x_0) = E sum_{t=0}^{infty} beta^t x_t' H x_t
+```math
+    q(x_0) = \mathbb{E} \sum_{t=0}^{\infty} \beta^t x_t' H x_t
+```
 
 
-Here {x_t} is the VAR process x_{t+1} = A x_t + C w_t with {w_t}
-standard normal and x_0 the initial condition.
+Here ``{x_t}`` is the VAR process ``x_{t+1} = A x_t + C w_t`` with ``{w_t}``
+standard normal and ``x_0`` the initial condition.
 
 ##### Arguments
-- `A::Union{Float64, Matrix{Float64}}` The n x n matrix described above (scalar)
+- `A::Union{Float64, Matrix{Float64}}` The `n x n` matrix described above (scalar)
 if n = 1
-- `C::Union{Float64, Matrix{Float64}}` The n x n matrix described above (scalar)
+- `C::Union{Float64, Matrix{Float64}}` The `n x n` matrix described above (scalar)
 if n = 1
-- `H::Union{Float64, Matrix{Float64}}` The n x n matrix described above (scalar)
+- `H::Union{Float64, Matrix{Float64}}` The `n x n` matrix described above (scalar)
 if n = 1
 - `beta::Float64`: Discount factor in (0, 1)
 - `x_0::Union{Float64, Vector{Float64}}` The initial condtion. A conformable
-array (of length n) or a scalar if n=1
+array (of length `n`) or a scalar if `n=1`
 
 ##### Returns
 
-- `q0::Float64` : Represents the value q(x_0)
+- `q0::Float64` : Represents the value ``q(x_0)``
 
 ##### Notes
 
-The formula for computing q(x_0) is q(x_0) = x_0' Q x_0 + v where
+The formula for computing ``q(x_0)`` is ``q(x_0) = x_0' Q x_0 + v`` where
 
-- Q is the solution to Q = H + beta A' Q A and
-- v = \trace(C' Q C) \beta / (1 - \beta)
+- ``Q`` is the solution to ``Q = H + \beta A' Q A`` and
+- ``v = trace(C' Q C) \beta / (1 - \beta)``
 
 """
 function var_quadratic_sum(A::ScalarOrArray, C::ScalarOrArray, H::ScalarOrArray,
@@ -56,26 +58,28 @@ function var_quadratic_sum(A::ScalarOrArray, C::ScalarOrArray, H::ScalarOrArray,
     return q0[1]
 end
 
-"""
+doc"""
 Computes the quadratic sum
 
-    V = sum_{j=0}^{infty} A^j B A^{j'}
+```math
+    V = \sum_{j=0}^{\infty} A^j B A^{j'}
+```
 
-V is computed by solving the corresponding discrete lyapunov equation using the
+``V`` is computed by solving the corresponding discrete lyapunov equation using the
 doubling algorithm.  See the documentation of `solve_discrete_lyapunov` for
 more information.
 
 ##### Arguments
 
-- `A::Matrix{Float64}` : An n x n matrix as described above.  We assume in order
-for convergence that the eigenvalues of A have moduli bounded by unity
-- `B::Matrix{Float64}` : An n x n matrix as described above.  We assume in order
-for convergence that the eigenvalues of B have moduli bounded by unity
+- `A::Matrix{Float64}` : An `n x n` matrix as described above.  We assume in order
+for convergence that the eigenvalues of ``A`` have moduli bounded by unity
+- `B::Matrix{Float64}` : An `n x n` matrix as described above.  We assume in order
+for convergence that the eigenvalues of ``B`` have moduli bounded by unity
 - `max_it::Int(50)` : Maximum number of iterations
 
 ##### Returns
 
-- `gamma1::Matrix{Float64}` : Represents the value V
+- `gamma1::Matrix{Float64}` : Represents the value ``V``
 
 """
 function m_quadratic_sum(A::Matrix, B::Matrix; max_it=50)

--- a/src/quadsums.jl
+++ b/src/quadsums.jl
@@ -19,14 +19,14 @@ standard normal and ``x_0`` the initial condition.
 
 ##### Arguments
 - `A::Union{Float64, Matrix{Float64}}` The `n x n` matrix described above (scalar)
-if n = 1
+  if `n = 1`
 - `C::Union{Float64, Matrix{Float64}}` The `n x n` matrix described above (scalar)
-if n = 1
+  if `n = 1`
 - `H::Union{Float64, Matrix{Float64}}` The `n x n` matrix described above (scalar)
-if n = 1
-- `beta::Float64`: Discount factor in (0, 1)
+  if `n = 1`
+- `beta::Float64`: Discount factor in `(0, 1)`
 - `x_0::Union{Float64, Vector{Float64}}` The initial condtion. A conformable
-array (of length `n`) or a scalar if `n=1`
+  array (of length `n`) or a scalar if `n = 1`
 
 ##### Returns
 
@@ -37,7 +37,7 @@ array (of length `n`) or a scalar if `n=1`
 The formula for computing ``q(x_0)`` is ``q(x_0) = x_0' Q x_0 + v`` where
 
 - ``Q`` is the solution to ``Q = H + \beta A' Q A`` and
-- ``v = trace(C' Q C) \beta / (1 - \beta)``
+- ``v = \frac{trace(C' Q C) \beta}{1 - \beta}``
 
 """
 function var_quadratic_sum(A::ScalarOrArray, C::ScalarOrArray, H::ScalarOrArray,
@@ -72,9 +72,9 @@ more information.
 ##### Arguments
 
 - `A::Matrix{Float64}` : An `n x n` matrix as described above.  We assume in order
-for convergence that the eigenvalues of ``A`` have moduli bounded by unity
+  for convergence that the eigenvalues of ``A`` have moduli bounded by unity
 - `B::Matrix{Float64}` : An `n x n` matrix as described above.  We assume in order
-for convergence that the eigenvalues of ``B`` have moduli bounded by unity
+  for convergence that the eigenvalues of ``B`` have moduli bounded by unity
 - `max_it::Int(50)` : Maximum number of iterations
 
 ##### Returns

--- a/src/robustlq.jl
+++ b/src/robustlq.jl
@@ -9,32 +9,36 @@ problems.
 References
 ----------
 
-http://quant-econ.net/jl/robustness.html
+https://lectures.quantecon.org/jl/robustness.html
 =#
 
-"""
+doc"""
 Represents infinite horizon robust LQ control problems of the form
 
-    min_{u_t}  sum_t beta^t {x_t' R x_t + u_t' Q u_t }
+```math
+    \min_{u_t} \sum_t \beta^t {x_t' R x_t + u_t' Q u_t }
+```
 
 subject to
 
+```math
     x_{t+1} = A x_t + B u_t + C w_{t+1}
+```
 
-and with model misspecification parameter theta.
+and with model misspecification parameter ``\theta``.
 
 ##### Fields
 
 - `Q::Matrix{Float64}` :  The cost(payoff) matrix for the controls. See above
-for more. `Q` should be k x k and symmetric and positive definite
+for more. ``Q`` should be `k x k` and symmetric and positive definite
 - `R::Matrix{Float64}` :  The cost(payoff) matrix for the state. See above for
-more. `R` should be n x n and symmetric and non-negative definite
+more. ``R`` should be `n x n` and symmetric and non-negative definite
 - `A::Matrix{Float64}` :  The matrix that corresponds with the state in the
-state space system. `A` should be n x n
+state space system. ``A`` should be `n x n`
 - `B::Matrix{Float64}` :  The matrix that corresponds with the control in the
-state space system.  `B` should be n x k
+state space system.  ``B`` should be `n x k`
 - `C::Matrix{Float64}` :  The matrix that corresponds with the random process in
-the state space system. `C` should be n x j
+the state space system. ``C`` should be `n x j`
 - `beta::Real` : The discount factor in the robust control problem
 - `theta::Real` The robustness factor in the robust control problem
 - `k, n, j::Int` : Dimensions of input matrices
@@ -69,19 +73,21 @@ function RBLQ(Q::ScalarOrArray, R::ScalarOrArray, A::ScalarOrArray,
     RBLQ(A, B, C, Q, R, k, n, j, bet, theta)
 end
 
-"""
-The D operator, mapping P into
+doc"""
+The ``D`` operator, mapping ``P`` into
 
-    D(P) := P + PC(theta I - C'PC)^{-1} C'P.
+```math
+    D(P) := P + PC(\theta I - C'PC)^{-1} C'P
+```
 
 ##### Arguments
 
 - `rlq::RBLQ`: Instance of `RBLQ` type
-- `P::Matrix{Float64}` : `size` is n x n
+- `P::Matrix{Float64}` : size is `n x n`
 
 ##### Returns
 
-- `dP::Matrix{Float64}` : The matrix P after applying the D operator
+- `dP::Matrix{Float64}` : The matrix ``P`` after applying the ``D`` operator
 
 """
 function d_operator(rlq::RBLQ, P::Matrix)
@@ -92,25 +98,28 @@ function d_operator(rlq::RBLQ, P::Matrix)
     return dP
 end
 
-"""
-The D operator, mapping P into
+doc"""
+The ``D`` operator, mapping ``P`` into
 
-    B(P) := R - beta^2 A'PB(Q + beta B'PB)^{-1}B'PA + beta A'PA
+```math
+    B(P) := R - \beta^2 A'PB(Q + \beta B'PB)^{-1}B'PA + \beta A'PA
+```
 
 and also returning
 
-    F := (Q + beta B'PB)^{-1} beta B'PA
-
+```math
+    F := (Q + \beta B'PB)^{-1} \beta B'PA
+```
 
 ##### Arguments
 
 - `rlq::RBLQ`: Instance of `RBLQ` type
-- `P::Matrix{Float64}` : `size` is n x n
+- `P::Matrix{Float64}` : size is `n x n`
 
 ##### Returns
 
-- `F::Matrix{Float64}` : The F matrix as defined above
-- `new_p::Matrix{Float64}` : The matrix P after applying the B operator
+- `F::Matrix{Float64}` : The ``F`` matrix as defined above
+- `new_p::Matrix{Float64}` : The matrix ``P`` after applying the ``B`` operator
 
 """
 function b_operator(rlq::RBLQ, P::Matrix)
@@ -126,16 +135,18 @@ function b_operator(rlq::RBLQ, P::Matrix)
     return F, new_P
 end
 
-"""
+doc"""
 Solves the robust control problem.
 
 The algorithm here tricks the problem into a stacked LQ problem, as described in
-chapter 2 of Hansen- Sargent's text "Robustness."  The optimal control with
+chapter 2 of Hansen- Sargent's text "Robustness".  The optimal control with
 observed state is
 
+```math
     u_t = - F x_t
+```
 
-And the value function is -x'Px
+And the value function is ``-x'Px``
 
 ##### Arguments
 
@@ -145,10 +156,8 @@ And the value function is -x'Px
 ##### Returns
 
 - `F::Matrix{Float64}` : The optimal control matrix from above
-- `P::Matrix{Float64}` : The positive semi-definite matrix defining the value
-function
-- `K::Matrix{Float64}` : the worst-case shock matrix `K`, where
-`w_{t+1} = K x_t` is the worst case shock
+- `P::Matrix{Float64}` : The positive semi-definite matrix defining the value function
+- `K::Matrix{Float64}` : the worst-case shock matrix ``K``, where ``w_{t+1} = K x_t`` is the worst case shock
 
 """
 function robust_rule(rlq::RBLQ)
@@ -172,14 +181,14 @@ function robust_rule(rlq::RBLQ)
 end
 
 
-"""
+doc"""
 Solve the robust LQ problem
 
-A simple algorithm for computing the robust policy F and the
-corresponding value function P, based around straightforward
+A simple algorithm for computing the robust policy ``F`` and the
+corresponding value function ``P``, based around straightforward
 iteration with the robust Bellman operator.  This function is
 easier to understand but one or two orders of magnitude slower
-than self.robust_rule().  For more information see the docstring
+than `self.robust_rule()`.  For more information see the docstring
 of that method.
 
 ##### Arguments
@@ -193,10 +202,8 @@ value function matrix
 ##### Returns
 
 - `F::Matrix{Float64}` : The optimal control matrix from above
-- `P::Matrix{Float64}` : The positive semi-definite matrix defining the value
-function
-- `K::Matrix{Float64}` : the worst-case shock matrix `K`, where
-`w_{t+1} = K x_t` is the worst case shock
+- `P::Matrix{Float64}` : The positive semi-definite matrix defining the value function
+- `K::Matrix{Float64}` : the worst-case shock matrix ``K``, where ``w_{t+1} = K x_t`` is the worst case shock
 
 """
 function robust_rule_simple(rlq::RBLQ,
@@ -227,19 +234,18 @@ function robust_rule_simple(rlq::RBLQ,
     return F, K, P
 end
 
-"""
-Compute agent 2's best cost-minimizing response `K`, given `F`.
+doc"""
+Compute agent 2's best cost-minimizing response ``K``, given ``F``.
 
 ##### Arguments
 
 - `rlq::RBLQ`: Instance of `RBLQ` type
-- `F::Matrix{Float64}`: A k x n array representing agent 1's policy
+- `F::Matrix{Float64}`: A `k x n` array representing agent 1's policy
 
 ##### Returns
 
-- `K::Matrix{Float64}` : Agent's best cost minimizing response corresponding to
-`F`
-- `P::Matrix{Float64}` : The value function corresponding to `F`
+- `K::Matrix{Float64}` : Agent's best cost minimizing response corresponding to `F`
+- `P::Matrix{Float64}` : The value function corresponding to ``F``
 
 """
 function F_to_K(rlq::RBLQ, F::Matrix)
@@ -259,19 +265,18 @@ function F_to_K(rlq::RBLQ, F::Matrix)
     return -neg_K, -neg_P
 end
 
-"""
-Compute agent 1's best cost-minimizing response `K`, given `F`.
+doc"""
+Compute agent 1's best cost-minimizing response ``K``, given ``F``.
 
 ##### Arguments
 
 - `rlq::RBLQ`: Instance of `RBLQ` type
-- `K::Matrix{Float64}`: A k x n array representing the worst case matrix
+- `K::Matrix{Float64}`: A `k x n` array representing the worst case matrix
 
 ##### Returns
 
-- `F::Matrix{Float64}` : Agent's best cost minimizing response corresponding to
-`K`
-- `P::Matrix{Float64}` : The value function corresponding to `K`
+- `F::Matrix{Float64}` : Agent's best cost minimizing response corresponding to ``K``
+- `P::Matrix{Float64}` : The value function corresponding to ``K``
 
 """
 function K_to_F(rlq::RBLQ, K::Matrix)
@@ -286,15 +291,15 @@ function K_to_F(rlq::RBLQ, K::Matrix)
     return F, P
 end
 
-"""
-Given `K` and `F`, compute the value of deterministic entropy, which is sum_t
-beta^t x_t' K'K x_t with x_{t+1} = (A - BF + CK) x_t.
+doc"""
+Given ``K`` and ``F``, compute the value of deterministic entropy, which is 
+``\sum_t \beta^t x_t' K'K x_t`` with ``x_{t+1} = (A - BF + CK) x_t``.
 
 ##### Arguments
 
 - `rlq::RBLQ`: Instance of `RBLQ` type
-- `F::Matrix{Float64}` The policy function, a k x n array
-- `K::Matrix{Float64}` The worst case matrix, a j x n array
+- `F::Matrix{Float64}` The policy function, a `k x n` array
+- `K::Matrix{Float64}` The worst case matrix, a `j x n` array
 - `x0::Vector{Float64}` : The initial condition for state
 
 ##### Returns
@@ -310,15 +315,15 @@ function compute_deterministic_entropy(rlq::RBLQ, F, K, x0)
     return var_quadratic_sum(A0, C0, H0, bet, x0)
 end
 
-"""
-Given a fixed policy `F`, with the interpretation u = -F x, this function
-computes the matrix P_F and constant d_F associated with discounted cost J_F(x) =
-x' P_F x + d_F.
+doc"""
+Given a fixed policy ``F``, with the interpretation ``u = -F x``, this function
+computes the matrix ``P_F`` and constant ``d_F`` associated with discounted cost
+``J_F(x) = x' P_F x + d_F``.
 
 ##### Arguments
 
 - `rlq::RBLQ`: Instance of `RBLQ` type
-- `F::Matrix{Float64}` :  The policy function, a k x n array
+- `F::Matrix{Float64}` :  The policy function, a `k x n` array
 
 ##### Returns
 

--- a/src/robustlq.jl
+++ b/src/robustlq.jl
@@ -238,7 +238,7 @@ Compute agent 2's best cost-minimizing response ``K``, given ``F``.
 
 ##### Returns
 
-- `K::Matrix{Float64}` : Agent's best cost minimizing response corresponding to `F`
+- `K::Matrix{Float64}` : Agent's best cost minimizing response corresponding to ``F``
 - `P::Matrix{Float64}` : The value function corresponding to ``F``
 
 """

--- a/src/robustlq.jl
+++ b/src/robustlq.jl
@@ -29,20 +29,14 @@ and with model misspecification parameter ``\theta``.
 
 ##### Fields
 
-- `Q::Matrix{Float64}` :  The cost(payoff) matrix for the controls. See above
-for more. ``Q`` should be `k x k` and symmetric and positive definite
-- `R::Matrix{Float64}` :  The cost(payoff) matrix for the state. See above for
-more. ``R`` should be `n x n` and symmetric and non-negative definite
-- `A::Matrix{Float64}` :  The matrix that corresponds with the state in the
-state space system. ``A`` should be `n x n`
-- `B::Matrix{Float64}` :  The matrix that corresponds with the control in the
-state space system.  ``B`` should be `n x k`
-- `C::Matrix{Float64}` :  The matrix that corresponds with the random process in
-the state space system. ``C`` should be `n x j`
+- `Q::Matrix{Float64}` :  The cost(payoff) matrix for the controls. See above for more. ``Q`` should be `k x k` and symmetric and positive definite
+- `R::Matrix{Float64}` :  The cost(payoff) matrix for the state. See above for more. ``R`` should be `n x n` and symmetric and non-negative definite
+- `A::Matrix{Float64}` :  The matrix that corresponds with the state in the state space system. ``A`` should be `n x n`
+- `B::Matrix{Float64}` :  The matrix that corresponds with the control in the state space system.  ``B`` should be `n x k`
+- `C::Matrix{Float64}` :  The matrix that corresponds with the random process in the state space system. ``C`` should be `n x j`
 - `beta::Real` : The discount factor in the robust control problem
 - `theta::Real` The robustness factor in the robust control problem
 - `k, n, j::Int` : Dimensions of input matrices
-
 
 """
 type RBLQ

--- a/src/zeros.jl
+++ b/src/zeros.jl
@@ -150,10 +150,10 @@ __zero_docstr_arg_ret = """
 - `x2::T`: Upper border for search interval
 - `;maxiter::Int(500)`: Maximum number of bisection iterations
 - `;xtol::Float64(1e-12)`: The routine converges when a root is known to lie
-within `xtol` of the value return. Should be >= 0. The routine modifies this to
-take into account the relative precision of doubles.
+  within `xtol` of the value return. Should be >= 0. The routine modifies this to
+  take into account the relative precision of doubles.
 - `;rtol::Float64(2*eps())`:The routine converges when a root is known to lie
-within `rtol` times the value returned of the value returned. Should be ≥ 0
+  within `rtol` times the value returned of the value returned. Should be ≥ 0
 
 ##### Returns
 
@@ -169,7 +169,7 @@ within `rtol` times the value returned of the value returned. Should be ≥ 0
 ## Bisection
 
 """
-Find the root of the `f` on the bracketing inverval `[x1, x2]` via bisection
+Find the root of the `f` on the bracketing inverval `[x1, x2]` via bisection.
 
 $__zero_docstr_arg_ret
 
@@ -322,7 +322,7 @@ function _brent_body{T<:AbstractFloat}(BE::BrentExtrapolation, f::Function,
 end
 
 """
-Find the root of the `f` on the bracketing inverval `[x1, x2]` via brent's algo
+Find the root of the `f` on the bracketing inverval `[x1, x2]` via brent's algo.
 
 $__zero_docstr_arg_ret
 


### PR DESCRIPTION
Yay it's pretty now

* added latex rendering to all docs
* updated links to lectures.quantecon.org
* tried to be more consistent with variable/value highlighting
* a lot of indenting to fix alignment of lists

@cc7768 Sorry I un-did all your unicode work but it wasn't displaying properly on my computer! Could you check the documentation now - I had to guess some of the notation. To build the docs, type `julia docs/make.jl` and open `docs/build/index.html`

* I think the structure/layout of the docs should be cleaned up - it's hard to navigate at the moment (although I don't know how to do this)
* I think this reference `scipy/scipy/optimize/Zeros/bisect.c` is outdated - might be worth linking [here](https://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.optimize.bisect.html) now
* Sometimes we say 'arguments', other times we say 'parameters'
* Not sure about the Fourier frequencies formula in estspec.jl