### PR TITLE
Add minimum version for Optim and NLopt

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -5,5 +5,5 @@ LightGraphs
 Primes
 Compat 0.18.0
 StatsBase
-Optim
+Optim 0.7.3
 NLopt

--- a/REQUIRE
+++ b/REQUIRE
@@ -6,4 +6,4 @@ Primes
 Compat 0.18.0
 StatsBase
 Optim 0.7.3
-NLopt
+NLopt 0.3.4


### PR DESCRIPTION
This PR should close #169 
- `Optim` needs to be v0.7.3 or more to use `Optim.Options` [here](https://github.com/QuantEcon/QuantEcon.jl/blob/master/src/markov/markov_approx.jl#L617). (See [Optim v0.7.3 release notes](https://github.com/JuliaNLSolvers/Optim.jl/blob/master/NEWS.md#optim-v073-release-notes))
- `NLopt` itself requres at least v0.3.4 to avoid [`Uint8` in v0.3.3](https://github.com/JuliaOpt/NLopt.jl/blob/v0.3.3/src/NLopt.jl#L389). ([`UInt8` in v0.3.4](https://github.com/JuliaOpt/NLopt.jl/blob/v0.3.4/src/NLopt.jl#L389))