### PR TITLE
WIP: Add short doc on golden_method

### DIFF
--- a/src/optimization.jl
+++ b/src/optimization.jl
@@ -43,6 +43,12 @@ end
 #     out_x, out_f
 # end
 
+"""
+Applies Golden-section search to search for the _maximum_ of a function in
+the interval (a, b)
+
+https://en.wikipedia.org/wiki/Golden-section_search
+"""
 function golden_method(f::Function, a::Real, b::Real; tol::Float64=10*eps(),
                        maxit::Int=1000)
     α1 = (3 - sqrt(5)) / 2


### PR DESCRIPTION
This adds documentation to the `golden_method` function.

Currently only adds for version with scalar bounds -- Will add docs to vector version as well once I make sure I understand what it does.

I will ping @sglyon once this is done.