### PR TITLE
Model tools: Add various utility functions

### DIFF
--- a/src/QuantEcon.jl
+++ b/src/QuantEcon.jl
@@ -53,6 +53,9 @@ export
     communication_classes, n_states,
     discrete_var, Even,
 
+# modeltools
+    AbstractUtility, LogUtility, CRRAUtility, derivative,
+
 # gth_solve
     gth_solve,
 
@@ -156,5 +159,6 @@ include("quad.jl")
 include("quadsums.jl")
 include("zeros.jl")
 include("optimization.jl")
+include("modeltools/utility.jl")
 
 end # module

--- a/src/QuantEcon.jl
+++ b/src/QuantEcon.jl
@@ -54,7 +54,7 @@ export
     discrete_var, Even,
 
 # modeltools
-    AbstractUtility, LogUtility, CRRAUtility, derivative,
+    AbstractUtility, LogUtility, CRRAUtility, ConstantFrisch, derivative,
 
 # gth_solve
     gth_solve,

--- a/src/QuantEcon.jl
+++ b/src/QuantEcon.jl
@@ -54,7 +54,7 @@ export
     discrete_var, Even,
 
 # modeltools
-    AbstractUtility, LogUtility, CRRAUtility, ConstantFrisch, derivative,
+    AbstractUtility, LogUtility, CRRAUtility, CFEUtility, EllipticalUtility, derivative,
 
 # gth_solve
     gth_solve,

--- a/src/modeltools/utility.jl
+++ b/src/modeltools/utility.jl
@@ -23,6 +23,21 @@ struct CRRAUtility <: AbstractUtility
 end
 
 (u::CRRAUtility)(c::Float64) = ifelse(c > 1e-10, u.ξ * (c^(1.0 - u.γ) - 1.0) / (1.0 - u.γ), -1e10)
-derivative(u::CRRAUtility, c::Float64) = ifelse(c > 1e-10, u.ξ * c^(-u.γ), -1e10)
+derivative(u::CRRAUtility, c::Float64) = ifelse(c > 1e-10, u.ξ * c^(-u.γ), 1e10)
 
+struct ConstantFrisch <: AbstractUtility
+    ϕ::Float64
+    ξ::Float64
+
+    function ConstantFrisch(ϕ, ξ=1.0)
+        if abs(ϕ - 1.0) < 1e-8
+            error("Your value for ϕ is very close to 1... Consider using LogUtility")
+        end
+
+        return new(ξ, γ)
+    end
+end
+
+(u::ConstantFrisch)(l::Float64) = ifelse(l > 1e-10, u.ξ * l^(1.0 + 1.0/u.ϕ)/(1.0 + 1.0/u.ϕ), -1e10)
+derivative(u::ConstantFrisch, l::Float64) = ifelse(l > 1e-10, u.ξ * l^(1.0/u.ϕ), 1e10)
 

--- a/src/modeltools/utility.jl
+++ b/src/modeltools/utility.jl
@@ -6,6 +6,16 @@ abstract type AbstractUtility end
 
 # Consumption utility
 
+"""
+Type used to evaluate log utility. Log utility takes the form
+
+u(c) = \log(c)
+
+Additionally, this code assumes that if c < 1e-10 then
+
+u(c) = log(1e-10) + 1e10*(c - 1e-10)
+
+"""
 struct LogUtility <: AbstractUtility
     ξ::Float64
 end
@@ -13,11 +23,19 @@ end
 LogUtility() = LogUtility(1.0)
 
 (u::LogUtility)(c::Float64) =
-    ifelse(c > 1e-10, u.ξ*log(c), -1e10)
+    ifelse(c > 1e-10, u.ξ*log(c), u.ξ*(log(1e-10) + 1e10*(c - 1e-10)))
 derivative(u::LogUtility, c::Float64) =
-    ifelse(c > 1e-10, u.ξ / c, 1e10)
+    ifelse(c > 1e-10, u.ξ / c, u.ξ*1e10)
 
+"""
+Type used to evaluate CRRA utility. CRRA utility takes the form
 
+u(c) = ξ c^(1 - γ) / (1 - γ)
+
+Additionally, this code assumes that if c < 1e-10 then
+
+u(c) = ξ (1e-10^(1 - γ) / (1 - γ) + 1e-10^(-γ) * (c - 1e-10))
+"""
 struct CRRAUtility <: AbstractUtility
     γ::Float64
     ξ::Float64
@@ -32,13 +50,25 @@ struct CRRAUtility <: AbstractUtility
 end
 
 (u::CRRAUtility)(c::Float64) =
-    ifelse(c > 1e-10, u.ξ * (c^(1.0 - u.γ) - 1.0) / (1.0 - u.γ), -1e10)
+    ifelse(c > 1e-10,
+           u.ξ * (c^(1.0 - u.γ) - 1.0) / (1.0 - u.γ),
+           u.ξ * ((1e-10^(1.0 - u.γ) - 1.0) / (1.0 - u.γ) + 1e-10^(-u.γ)*(c - 1e-10)))
 derivative(u::CRRAUtility, c::Float64) =
-    ifelse(c > 1e-10, u.ξ * c^(-u.γ), 1e10)
+    ifelse(c > 1e-10, u.ξ * c^(-u.γ), u.ξ*1e-10^(-u.γ))
 
 
 # Labor Utility
 
+"""
+Type used to evaluate constant Frisch elasticity (CFE) utility. CFE
+utility takes the form
+
+v(l) = ξ l^(1 + 1/ϕ) / (1 + 1/ϕ)
+
+Additionally, this code assumes that if l < 1e-10 then
+
+v(l) = ξ (1e-10^(1 + 1/ϕ) / (1 + 1/ϕ) - 1e-10^(1/ϕ) * (1e-10 - l))
+"""
 struct CFEUtility <: AbstractUtility
     ϕ::Float64
     ξ::Float64
@@ -53,11 +83,18 @@ struct CFEUtility <: AbstractUtility
 end
 
 (u::CFEUtility)(l::Float64) =
-    ifelse(l > 1e-10, -u.ξ * l^(1.0 + 1.0/u.ϕ)/(1.0 + 1.0/u.ϕ), -1e10)
+    ifelse(l > 1e-10,
+           -u.ξ * l^(1.0 + 1.0/u.ϕ)/(1.0 + 1.0/u.ϕ),
+           -u.ξ * (1e-10^(1.0 + 1.0/u.ϕ)/(1.0 + 1.0/u.ϕ) + 1e-10^(1.0/u.ϕ) * (l - 1e-10)))
 derivative(u::CFEUtility, l::Float64) =
-    ifelse(l > 1e-10, -u.ξ * l^(1.0/u.ϕ), 1e10)
+    ifelse(l > 1e-10, -u.ξ * l^(1.0/u.ϕ), -u.ξ * 1e-10^(1.0/u.ϕ))
 
 
+"""
+Type used to evaluate elliptical utility function. Elliptical utility takes form
+
+v(l) = b (1 - l^μ)^(1 / μ)
+"""
 struct EllipticalUtility <: AbstractUtility
     b::Float64
     μ::Float64

--- a/src/modeltools/utility.jl
+++ b/src/modeltools/utility.jl
@@ -27,7 +27,7 @@ struct CRRAUtility <: AbstractUtility
             error("Your value for γ is very close to 1... Consider using LogUtility")
         end
 
-        return new(ξ, γ)
+        return new(γ, ξ)
     end
 end
 
@@ -39,23 +39,23 @@ derivative(u::CRRAUtility, c::Float64) =
 
 # Labor Utility
 
-struct CFUtility <: AbstractUtility
+struct CFEUtility <: AbstractUtility
     ϕ::Float64
     ξ::Float64
 
-    function CFUtility(ϕ, ξ=1.0)
+    function CFEUtility(ϕ, ξ=1.0)
         if abs(ϕ - 1.0) < 1e-8
             error("Your value for ϕ is very close to 1... Consider using LogUtility")
         end
 
-        return new(ξ, γ)
+        return new(ϕ, ξ)
     end
 end
 
-(u::CFUtility)(l::Float64) =
-    ifelse(l > 1e-10, u.ξ * l^(1.0 + 1.0/u.ϕ)/(1.0 + 1.0/u.ϕ), -1e10)
-derivative(u::CFUtility, l::Float64) =
-    ifelse(l > 1e-10, u.ξ * l^(1.0/u.ϕ), 1e10)
+(u::CFEUtility)(l::Float64) =
+    ifelse(l > 1e-10, -u.ξ * l^(1.0 + 1.0/u.ϕ)/(1.0 + 1.0/u.ϕ), -1e10)
+derivative(u::CFEUtility, l::Float64) =
+    ifelse(l > 1e-10, -u.ξ * l^(1.0/u.ϕ), 1e10)
 
 
 struct EllipticalUtility <: AbstractUtility

--- a/src/modeltools/utility.jl
+++ b/src/modeltools/utility.jl
@@ -1,13 +1,22 @@
 abstract type AbstractUtility end
 
+#
+# Separable utility
+#
+
+# Consumption utility
+
 struct LogUtility <: AbstractUtility
     ξ::Float64
 end
 
 LogUtility() = LogUtility(1.0)
 
-(u::LogUtility)(c::Float64) = ifelse(c > 1e-10, u.ξ*log(c), -1e10)
-derivative(u::LogUtility, c::Float64) = ifelse(c > 1e-10, u.ξ / c, 1e10)
+(u::LogUtility)(c::Float64) =
+    ifelse(c > 1e-10, u.ξ*log(c), -1e10)
+derivative(u::LogUtility, c::Float64) =
+    ifelse(c > 1e-10, u.ξ / c, 1e10)
+
 
 struct CRRAUtility <: AbstractUtility
     γ::Float64
@@ -22,14 +31,19 @@ struct CRRAUtility <: AbstractUtility
     end
 end
 
-(u::CRRAUtility)(c::Float64) = ifelse(c > 1e-10, u.ξ * (c^(1.0 - u.γ) - 1.0) / (1.0 - u.γ), -1e10)
-derivative(u::CRRAUtility, c::Float64) = ifelse(c > 1e-10, u.ξ * c^(-u.γ), 1e10)
+(u::CRRAUtility)(c::Float64) =
+    ifelse(c > 1e-10, u.ξ * (c^(1.0 - u.γ) - 1.0) / (1.0 - u.γ), -1e10)
+derivative(u::CRRAUtility, c::Float64) =
+    ifelse(c > 1e-10, u.ξ * c^(-u.γ), 1e10)
 
-struct ConstantFrisch <: AbstractUtility
+
+# Labor Utility
+
+struct CFUtility <: AbstractUtility
     ϕ::Float64
     ξ::Float64
 
-    function ConstantFrisch(ϕ, ξ=1.0)
+    function CFUtility(ϕ, ξ=1.0)
         if abs(ϕ - 1.0) < 1e-8
             error("Your value for ϕ is very close to 1... Consider using LogUtility")
         end
@@ -38,6 +52,22 @@ struct ConstantFrisch <: AbstractUtility
     end
 end
 
-(u::ConstantFrisch)(l::Float64) = ifelse(l > 1e-10, u.ξ * l^(1.0 + 1.0/u.ϕ)/(1.0 + 1.0/u.ϕ), -1e10)
-derivative(u::ConstantFrisch, l::Float64) = ifelse(l > 1e-10, u.ξ * l^(1.0/u.ϕ), 1e10)
+(u::CFUtility)(l::Float64) =
+    ifelse(l > 1e-10, u.ξ * l^(1.0 + 1.0/u.ϕ)/(1.0 + 1.0/u.ϕ), -1e10)
+derivative(u::CFUtility, l::Float64) =
+    ifelse(l > 1e-10, u.ξ * l^(1.0/u.ϕ), 1e10)
+
+
+struct EllipticalUtility <: AbstractUtility
+    b::Float64
+    μ::Float64
+end
+
+# These defaults are pulled straight from Evans Phillips 2017
+EllipticalUtility(;b=0.5223, μ=2.2926) = EllipticalUtility(b, μ)
+
+(u::EllipticalUtility)(l::Float64) =
+    u.b * (1.0 - l^u.μ)^(1.0 / u.μ)
+derivative(u::EllipticalUtility, l::Float64) =
+    -u.b * (1.0 - l^u.μ)^(1.0/u.μ - 1.0) * l^(u.μ - 1.0)
 

--- a/src/modeltools/utility.jl
+++ b/src/modeltools/utility.jl
@@ -1,0 +1,28 @@
+abstract type AbstractUtility end
+
+struct LogUtility <: AbstractUtility
+    ξ::Float64
+end
+
+LogUtility() = LogUtility(1.0)
+
+(u::LogUtility)(c::Float64) = ifelse(c > 1e-10, u.ξ*log(c), -1e10)
+derivative(u::LogUtility, c::Float64) = ifelse(c > 1e-10, u.ξ / c, 1e10)
+
+struct CRRAUtility <: AbstractUtility
+    γ::Float64
+    ξ::Float64
+
+    function CRRAUtility(γ, ξ=1.0)
+        if abs(γ - 1.0) < 1e-8
+            error("Your value for γ is very close to 1... Consider using LogUtility")
+        end
+
+        return new(ξ, γ)
+    end
+end
+
+(u::CRRAUtility)(c::Float64) = ifelse(c > 1e-10, u.ξ * (c^(1.0 - u.γ) - 1.0) / (1.0 - u.γ), -1e10)
+derivative(u::CRRAUtility, c::Float64) = ifelse(c > 1e-10, u.ξ * c^(-u.γ), -1e10)
+
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,7 @@ tests = [
         "markov_approx",
         "matrix_eqn",
         "mc_tools",
+        "modeltool",
         "quad",
         "quadsum",
         "random_mc",

--- a/test/test_modeltool.jl
+++ b/test/test_modeltool.jl
@@ -9,6 +9,12 @@
     @test u(2.0) > u(1.0)  # Ensure it is increasing
     @test isapprox(derivative(u, 1.0), 2.0)
     @test isapprox(derivative(u, 2.0), 1.0)
+
+    # Test "extrapolation evaluations"
+    @test isapprox(u(0.5e-10), u(1e-10) + derivative(u, 1e-10)*(0.5e-10 - 1e-10))
+
+    @test isapprox(LogUtility().ξ, 1.0)  # Test default constructor
+
     end
 
     @testset "CRRA Utility" begin
@@ -20,16 +26,26 @@
     @test u(5.0) > u(3.0)  # Ensure it is increasing
     @test isapprox(derivative(u, 1.0), 1.0)
     @test isapprox(derivative(u, 2.0), 0.25)
+
+    # Test "extrapolation evaluations"
+    @test isapprox(u(0.5e-10), u(1e-10) + derivative(u, 1e-10)*(0.5e-10 - 1e-10))
+
+    @test_throws ErrorException CRRAUtility(1.0)  # Test error throwing at γ=1.0
     end
 
     @testset "CFE Utility" begin
     # Test CFE Utility
-    u = CFEUtility(2.0)
-    @test isapprox(u(1.0), -2.0/3.0)
-    @test isapprox(u(0.5), -u.ξ * 0.5^(1.0 + 1.0/u.ϕ) / (1.0 + 1.0/u.ϕ))
-    @test u(0.5) > u(0.85)  # Ensure it is decreasing
-    @test isapprox(derivative(u, 0.25), -0.5)
-    @test isapprox(derivative(u, 1.0), -1.0)
+    v = CFEUtility(2.0)
+    @test isapprox(v(1.0), -2.0/3.0)
+    @test isapprox(v(0.5), -v.ξ * 0.5^(1.0 + 1.0/v.ϕ) / (1.0 + 1.0/v.ϕ))
+    @test v(0.5) > v(0.85)  # Ensure it is decreasing
+    @test isapprox(derivative(v, 0.25), -0.5)
+    @test isapprox(derivative(v, 1.0), -1.0)
+
+    # Test "extrapolation evaluations"
+    @test isapprox(v(0.5e-10), v(1e-10) + derivative(v, 1e-10)*(0.5e-10 - 1e-10))
+
+    @test_throws ErrorException CRRAUtility(1.0)  # Test error throwing at ϕ=1.0
     end
 
     @testset "Elliptical Utility" begin
@@ -40,6 +56,10 @@
     @test u(0.5) > u(0.95)  # Ensure it is decreasing
     @test isapprox(derivative(u, 0.0), 0.0)
     @test isapprox(derivative(u, sqrt(0.5)), -1.0)
+
+    # Test default values
+    @test isapprox(EllipticalUtility().b, 0.5223)
+    @test isapprox(EllipticalUtility().μ, 2.2926)
     end
 
 end

--- a/test/test_modeltool.jl
+++ b/test/test_modeltool.jl
@@ -1,0 +1,45 @@
+@testset "Testing modeltools.jl" begin
+
+    @testset "Log Utility" begin
+    # Test log utility
+    u = LogUtility(2.0)
+    @test isapprox(u(1.0), 0.0)
+    @test isapprox(2.0*log(2.5), u(2.5))
+    @test isapprox(u.(ones(5)), zeros(5))
+    @test u(2.0) > u(1.0)  # Ensure it is increasing
+    @test isapprox(derivative(u, 1.0), 2.0)
+    @test isapprox(derivative(u, 2.0), 1.0)
+    end
+
+    @testset "CRRA Utility" begin
+    # Test CRRA utility
+    u = CRRAUtility(2.0)
+    @test isapprox(u(1.0), 0.0)
+    @test isapprox((2.5^(-1.0) - 1.0) / (-1.0), u(2.5))
+    @test isapprox(u.(ones(5)), zeros(5))
+    @test u(5.0) > u(3.0)  # Ensure it is increasing
+    @test isapprox(derivative(u, 1.0), 1.0)
+    @test isapprox(derivative(u, 2.0), 0.25)
+    end
+
+    @testset "CFE Utility" begin
+    # Test CFE Utility
+    u = CFEUtility(2.0)
+    @test isapprox(u(1.0), -2.0/3.0)
+    @test isapprox(u(0.5), -u.ξ * 0.5^(1.0 + 1.0/u.ϕ) / (1.0 + 1.0/u.ϕ))
+    @test u(0.5) > u(0.85)  # Ensure it is decreasing
+    @test isapprox(derivative(u, 0.25), -0.5)
+    @test isapprox(derivative(u, 1.0), -1.0)
+    end
+
+    @testset "Elliptical Utility" begin
+    # Test Elliptical Utility
+    u = EllipticalUtility(1.0, 2.0)
+    @test isapprox(u(sqrt(0.75)), 0.5)
+    @test isapprox(u(sqrt(0.51)), 0.7)
+    @test u(0.5) > u(0.95)  # Ensure it is decreasing
+    @test isapprox(derivative(u, 0.0), 0.0)
+    @test isapprox(derivative(u, sqrt(0.5)), -1.0)
+    end
+
+end


### PR DESCRIPTION
In this pull request, I introduce an abstract type `AbstractUtility`. I also include 4 concrete utility functions and their derivatives: `LogUtility`, `CRRAUtility`, `CFEUtility`, and `EllipticalUtility` -- The first two are typically used in modeling consumption utility and second two for labor utility.

Additionally, the folder `modeltools` can be a placeholder for adding things like production functions etc... in the future.

Example

```julia
using QuantEcon

u = LogUtility()

# Evaluate log utility at c=1
@show u(1.0)

# Evaluate derivative of log utility at c=1
@show derivative(u, 1.0)
```

@sglyon 
