### PR TITLE
WIP: Fix utility functions to branch

### DIFF
--- a/src/modeltools/utility.jl
+++ b/src/modeltools/utility.jl
@@ -23,9 +23,9 @@ end
 LogUtility() = LogUtility(1.0)
 
 (u::LogUtility)(c::Float64) =
-    ifelse(c > 1e-10, u.ξ*log(c), u.ξ*(log(1e-10) + 1e10*(c - 1e-10)))
+    c > 1e-10 ? u.ξ*log(c) : u.ξ*(log(1e-10) + 1e10*(c - 1e-10))
 derivative(u::LogUtility, c::Float64) =
-    ifelse(c > 1e-10, u.ξ / c, u.ξ*1e10)
+    c > 1e-10 ? u.ξ / c : u.ξ*1e10
 
 """
 Type used to evaluate CRRA utility. CRRA utility takes the form
@@ -50,11 +50,11 @@ struct CRRAUtility <: AbstractUtility
 end
 
 (u::CRRAUtility)(c::Float64) =
-    ifelse(c > 1e-10,
-           u.ξ * (c^(1.0 - u.γ) - 1.0) / (1.0 - u.γ),
-           u.ξ * ((1e-10^(1.0 - u.γ) - 1.0) / (1.0 - u.γ) + 1e-10^(-u.γ)*(c - 1e-10)))
+    c > 1e-10 ?
+           u.ξ * (c^(1.0 - u.γ) - 1.0) / (1.0 - u.γ) :
+           u.ξ * ((1e-10^(1.0 - u.γ) - 1.0) / (1.0 - u.γ) + 1e-10^(-u.γ)*(c - 1e-10))
 derivative(u::CRRAUtility, c::Float64) =
-    ifelse(c > 1e-10, u.ξ * c^(-u.γ), u.ξ*1e-10^(-u.γ))
+    c > 1e-10 ? u.ξ * c^(-u.γ) : u.ξ*1e-10^(-u.γ)
 
 
 # Labor Utility
@@ -83,11 +83,11 @@ struct CFEUtility <: AbstractUtility
 end
 
 (u::CFEUtility)(l::Float64) =
-    ifelse(l > 1e-10,
-           -u.ξ * l^(1.0 + 1.0/u.ϕ)/(1.0 + 1.0/u.ϕ),
-           -u.ξ * (1e-10^(1.0 + 1.0/u.ϕ)/(1.0 + 1.0/u.ϕ) + 1e-10^(1.0/u.ϕ) * (l - 1e-10)))
+    l > 1e-10 ?
+           -u.ξ * l^(1.0 + 1.0/u.ϕ)/(1.0 + 1.0/u.ϕ) :
+           -u.ξ * (1e-10^(1.0 + 1.0/u.ϕ)/(1.0 + 1.0/u.ϕ) + 1e-10^(1.0/u.ϕ) * (l - 1e-10))
 derivative(u::CFEUtility, l::Float64) =
-    ifelse(l > 1e-10, -u.ξ * l^(1.0/u.ϕ), -u.ξ * 1e-10^(1.0/u.ϕ))
+    l > 1e-10 ? -u.ξ * l^(1.0/u.ϕ) : -u.ξ * 1e-10^(1.0/u.ϕ)
 
 
 """

--- a/test/test_modeltool.jl
+++ b/test/test_modeltool.jl
@@ -12,6 +12,7 @@
 
     # Test "extrapolation evaluations"
     @test isapprox(u(0.5e-10), u(1e-10) + derivative(u, 1e-10)*(0.5e-10 - 1e-10))
+    @test u(-0.5) < u(-0.1)  # Make sure it doesn't fail with negative values
 
     @test isapprox(LogUtility().ξ, 1.0)  # Test default constructor
 
@@ -29,6 +30,7 @@
 
     # Test "extrapolation evaluations"
     @test isapprox(u(0.5e-10), u(1e-10) + derivative(u, 1e-10)*(0.5e-10 - 1e-10))
+    @test u(-0.5) < u(-0.1)  # Make sure it doesn't fail with negative values
 
     @test_throws ErrorException CRRAUtility(1.0)  # Test error throwing at γ=1.0
     end
@@ -44,6 +46,7 @@
 
     # Test "extrapolation evaluations"
     @test isapprox(v(0.5e-10), v(1e-10) + derivative(v, 1e-10)*(0.5e-10 - 1e-10))
+    @test v(-0.5) < v(-0.1)  # Make sure it doesn't fail with negative values
 
     @test_throws ErrorException CRRAUtility(1.0)  # Test error throwing at ϕ=1.0
     end
@@ -60,6 +63,7 @@
     # Test default values
     @test isapprox(EllipticalUtility().b, 0.5223)
     @test isapprox(EllipticalUtility().μ, 2.2926)
+
     end
 
 end

--- a/test/test_modeltool.jl
+++ b/test/test_modeltool.jl
@@ -46,7 +46,7 @@
 
     # Test "extrapolation evaluations"
     @test isapprox(v(0.5e-10), v(1e-10) + derivative(v, 1e-10)*(0.5e-10 - 1e-10))
-    @test v(-0.5) < v(-0.1)  # Make sure it doesn't fail with negative values
+    @test v(-0.5) > v(-0.1)  # Make sure it doesn't fail with negative values
 
     @test_throws ErrorException CRRAUtility(1.0)  # Test error throwing at ϕ=1.0
     end


### PR DESCRIPTION
The utility functions were using `ifelse` to evaluate in places where the utility function couldn't be evaluated -- This doesn't work because it evaluates both cases at once and it throws an error.

This is WIP and still needs some tests to check this and potentially some other cases.

For example

```
u = LogUtility()

# Should just do linear approximation around 1e-10 and extrapolating down, but throws error
u(-0.01) 
```