### PR TITLE
Add `next_k_array!` and `k_array_rank`.

### DIFF
--- a/src/QuantEcon.jl
+++ b/src/QuantEcon.jl
@@ -97,6 +97,7 @@ export
 
 # util
     meshgrid, gridmake, gridmake!, ckron, is_stable, num_compositions, simplex_grid, simplex_index,
+    next_k_array!, k_array_rank,
 
 # robustlq
     RBLQ,

--- a/src/util.jl
+++ b/src/util.jl
@@ -340,10 +340,10 @@ the descending sequences of the elements, following
 
 # Notes
 
-`InexactError` exception will be thrown if overflow occurs during
-the computation. It is the user's responsibility to ensure
-that the rank of the input array fits within the range of `T`;
-a sufficient condition for it is 
+`InexactError` exception will be thrown, or an incorrect value will be
+returned without warning if overflow occurs during the computation.
+It is the user's responsibility to ensure that the rank of the input
+array fits within the range of `T`; a sufficient condition for it is 
 `binomial(BigInt(a[end]), BigInt(length(a))) <= typemax(T)`.
 
 # Arguments

--- a/src/util.jl
+++ b/src/util.jl
@@ -270,3 +270,92 @@ function simplex_index(x, m, n)
     return idx
 end
 
+"""
+    next_k_array!(a)
+
+Given an array `a` of k distinct positive integers, sorted in
+ascending order, return the next k-array in the lexicographic
+ordering of the descending sequences of the elements, following
+[Combinatorial number system]
+(https://en.wikipedia.org/wiki/Combinatorial_number_system). `a` is
+modified in place.
+
+# Arguments
+
+- `a::Vector{T}`: Array of length k. T<:Integer.
+
+# Returns
+
+- `a::Vector{T}`: View of `a`.
+
+# Examples
+
+```julia
+julia> n, k = 4, 2;
+
+julia> a = collect(1:2);
+
+julia> while a[end] <= n
+           @show a
+           next_k_array!(a)
+       end
+a = [1, 2]
+a = [1, 3]
+a = [2, 3]
+a = [1, 4]
+a = [2, 4]
+a = [3, 4]
+```
+"""
+function next_k_array!(a::Vector{T}) where T <: Integer
+
+    k = length(a)
+    if k == 1 || a[1] + 1 < a[2]
+        a[1] += 1
+        return a
+    end
+
+    a[1] = 1
+    i = 2
+    x = a[i] + 1
+
+    while i < k && x == a[i+1]
+        i += 1
+        a[i-1] = i - 1
+        x = a[i] + 1
+    end
+    a[i] = x
+
+    return a
+end
+
+"""
+    k_array_rank(a)
+
+Given an array `a` of k distinct positive integers, sorted in
+ascending order, return its ranking in the lexicographic ordering of
+the descending sequences of the elements, following
+[Combinatorial number system]
+(https://en.wikipedia.org/wiki/Combinatorial_number_system).
+
+# Arguments
+
+- `a::Vector{T}`: Array of length k. T<:Integer.
+
+# Returns
+
+- `idx::Integer`: Ranking of `a`.
+"""
+function k_array_rank(a::Vector{T}) where T <: Integer
+    k = length(a)
+    idx = one(T)
+    for i = 1:k
+        try
+            idx += binomial(a[i]-1, i)
+        catch InexactError
+            idx += binomial(BigInt(a[i]-1), BigInt(i))
+        end
+    end
+    
+    return idx
+end

--- a/src/util.jl
+++ b/src/util.jl
@@ -282,11 +282,11 @@ modified in place.
 
 # Arguments
 
-- `a::Vector{T}`: Array of length k. T<:Integer.
+- `a::Vector{<:Integer}`: Array of length k.
 
 # Returns
 
-- `a::Vector{T}`: View of `a`.
+- `a::Vector{<:Integer}`: View of `a`.
 
 # Examples
 
@@ -307,7 +307,7 @@ a = [2, 4]
 a = [3, 4]
 ```
 """
-function next_k_array!(a::Vector{T}) where T <: Integer
+function next_k_array!(a::Vector{<:Integer})
 
     k = length(a)
     if k == 1 || a[1] + 1 < a[2]
@@ -330,7 +330,7 @@ function next_k_array!(a::Vector{T}) where T <: Integer
 end
 
 """
-    k_array_rank(a)
+    k_array_rank([T=Int], a)
 
 Given an array `a` of k distinct positive integers, sorted in
 ascending order, return its ranking in the lexicographic ordering of
@@ -338,24 +338,31 @@ the descending sequences of the elements, following
 [Combinatorial number system]
 (https://en.wikipedia.org/wiki/Combinatorial_number_system).
 
+# Notes
+
+`InexactError` exception will be thrown if overflow occurs during
+the computation. It is the user's responsibility to ensure
+that the rank of the input array fits within the range of `T`;
+a sufficient condition for it is 
+`binomial(BigInt(a[end]), BigInt(length(a))) <= typemax(T)`.
+
 # Arguments
 
-- `a::Vector{T}`: Array of length k. T<:Integer.
+- `T::Type{<:Integer}`: The numeric type of ranking to be returned.
+- `a::Vector{<:Integer}`: Array of length k.
 
 # Returns
 
-- `idx::Integer`: Ranking of `a`.
+- `idx::T`: Ranking of `a`.
 """
-function k_array_rank(a::Vector{T}) where T <: Integer
+function k_array_rank(T::Type{<:Integer}, a::Vector{<:Integer})
     k = length(a)
     idx = one(T)
     for i = 1:k
-        try
-            idx += binomial(a[i]-1, i)
-        catch InexactError
-            idx += binomial(BigInt(a[i]-1), BigInt(i))
-        end
+        idx += binomial(T(a[i])-one(T), T(i))
     end
-    
+
     return idx
 end
+
+k_array_rank(a::Vector{<:Integer}) = k_array_rank(Int, a)

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -113,8 +113,9 @@
 
         @test k_arrays_computed == k_arrays
 
-        n, k = BigInt(100), BigInt(50)
-        @test k_array_rank(collect(n-k+1:n)) == binomial(n, k)
+        n, k = 100, 50
+        @test k_array_rank(BigInt, collect(n-k+1:n)) == binomial(BigInt(n), BigInt(k))
+        @test_throws InexactError k_array_rank(collect(n-k+1:n))
 
     end
 

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -79,4 +79,43 @@
         @test simplex_grid(5, 4) == reshape(grid_5_4', 5, 70)
     end
 
+    @testset "next_k_array" begin
+        
+        k_arrays = [1  2  3;
+                    1  2  4;
+                    1  3  4;
+                    2  3  4;
+                    1  2  5;
+                    1  3  5;
+                    2  3  5;
+                    1  4  5;
+                    2  4  5;
+                    3  4  5;
+                    1  2  6;
+                    1  3  6;
+                    2  3  6;
+                    1  4  6;
+                    2  4  6;
+                    3  4  6;
+                    1  5  6;
+                    2  5  6;
+                    3  5  6;
+                    4  5  6]
+        L, k = size(k_arrays)
+
+        k_arrays_computed = similar(k_arrays)
+        k_arrays_computed[1, :] = collect(1:k)
+        @test k_array_rank(k_arrays_computed[1, :]) == 1
+        for i = 2:L
+            k_arrays_computed[i, :] = next_k_array!(k_arrays_computed[i-1, :])
+            @test k_array_rank(k_arrays_computed[i, :]) == i
+        end
+
+        @test k_arrays_computed == k_arrays
+
+        n, k = BigInt(100), BigInt(50)
+        @test k_array_rank(collect(n-k+1:n)) == binomial(n, k)
+
+    end
+
 end

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -113,9 +113,15 @@
 
         @test k_arrays_computed == k_arrays
 
+        # test InexactError when ranking is out of range
         n, k = 100, 50
         @test k_array_rank(BigInt, collect(n-k+1:n)) == binomial(BigInt(n), BigInt(k))
         @test_throws InexactError k_array_rank(collect(n-k+1:n))
+
+        # test returning wrong value when ranking is out of range
+        n, k = 68, 29
+        @test k_array_rank(BigInt, collect(n-k+1:n)) == binomial(BigInt(n), BigInt(k))
+        @test k_array_rank(collect(n-k+1:n)) != binomial(BigInt(n), BigInt(k))
 
     end
 


### PR DESCRIPTION
Add `next_k_array!` and `k_array_rank` utilities, mimicking the [counterpart Python version](https://github.com/QuantEcon/QuantEcon.py/blob/e61702fd6622ae046d8252b38ab101454c2e74b2/quantecon/util/combinatorics.py#L12) implemented by @oyamad. It is mainly copying and pasting, and modifying a little part (let index start from 1 rather than 0).