### PR TITLE
Fix 0.7 errors (for using QuantEcon)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: julia
 sudo: false
-os: 
+os:
     - linux
 addons:
   apt:
@@ -9,9 +9,11 @@ addons:
     - hdf5-tools
 julia:
     - 0.6
+    - 0.7
     - nightly
 matrix:
     allow_failures:
+        - julia: 0.7
         - julia: nightly
 notifications:
     email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -7,3 +7,4 @@ Compat 0.18.0
 StatsBase
 Optim 0.9.0
 NLopt 0.3.4
+Nullables

--- a/REQUIRE
+++ b/REQUIRE
@@ -8,3 +8,4 @@ StatsBase
 Optim 0.9.0
 NLopt 0.3.4
 Nullables
+Compat 0.48.0

--- a/src/QuantEcon.jl
+++ b/src/QuantEcon.jl
@@ -16,6 +16,11 @@ using StatsBase:ecdf
     using Base.Iterators: cycle, take
 end
 
+# 0.6/0.7 compatibility
+using Compat
+using Compat.LinearAlgebra
+using Compat.Random
+
 # useful types
 ScalarOrArray{T} = Union{T,Array{T}}
 

--- a/src/QuantEcon.jl
+++ b/src/QuantEcon.jl
@@ -20,6 +20,7 @@ end
 using Compat
 using Compat.LinearAlgebra
 using Compat.Random
+using Compat.SparseArrays
 
 # useful types
 ScalarOrArray{T} = Union{T,Array{T}}

--- a/src/discrete_rv.jl
+++ b/src/discrete_rv.jl
@@ -53,7 +53,7 @@ Make a single draw from the discrete distribution.
 
 - `out::Int`: One draw from the discrete distribution
 """
-Base.rand(d::DiscreteRV) = searchsortedfirst(d.Q, rand())
+Random.rand(d::DiscreteRV) = searchsortedfirst(d.Q, rand())
 
 """
 Make multiple draws from the discrete distribution represented by a
@@ -68,13 +68,13 @@ Make multiple draws from the discrete distribution represented by a
 
 - `out::Vector{Int}`: `k` draws from `d`
 """
-Base.rand(d::DiscreteRV, k::Int) = Int[rand(d) for i=1:k]
+Random.rand(d::DiscreteRV, k::Int) = Int[rand(d) for i=1:k]
 
-function Base.rand!(out::AbstractArray{T}, d::DiscreteRV) where T<:Integer
+function Random.rand!(out::AbstractArray{T}, d::DiscreteRV) where T<:Integer
     @inbounds for I in eachindex(out)
         out[I] = rand(d)
     end
     out
 end
 
-@deprecate draw Base.rand
+@deprecate draw Random.rand

--- a/src/markov/ddp.jl
+++ b/src/markov/ddp.jl
@@ -23,6 +23,7 @@ Notes
 =#
 
 import Base: *
+using Nullables
 
 #------------------------#
 #-Types and Constructors-#
@@ -72,7 +73,7 @@ mutable struct DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind,TQ<:AbstractArray{T,NQ}
         if size(Q) != (num_states, num_actions, num_states)
             throw(ArgumentError("shapes of R and Q must be (n,m) and (n,m,n)"))
         end
-	
+
         # check feasibility
         R_max = s_wise_max(R)
         if any(R_max .== -Inf)

--- a/src/modeltools/utility.jl
+++ b/src/modeltools/utility.jl
@@ -6,7 +6,7 @@ abstract type AbstractUtility end
 
 # Consumption utility
 
-"""
+doc"""
 Type used to evaluate log utility. Log utility takes the form
 
 u(c) = \log(c)

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -3,8 +3,9 @@
 =#
 
 import Base: ==
+import Compat.LinearAlgebra: BlasReal
 
-struct MVNSampler{TM<:Real,TS<:Real,TQ<:LinAlg.BlasReal}
+struct MVNSampler{TM<:Real,TS<:Real,TQ<:BlasReal}
     mu::Vector{TM}
     Sigma::Matrix{TS}
     Q::Matrix{TQ}
@@ -51,14 +52,14 @@ function MVNSampler(mu::Vector{TM}, Sigma::Matrix{TS}) where {TM<:Real,TS<:Real}
 end
 
 # methods with the optional rng argument first
-Base.rand(rng::AbstractRNG, d::MVNSampler) =
+Random.rand(rng::AbstractRNG, d::MVNSampler) =
     d.mu + d.Q * randn(rng, length(d.mu))
-Base.rand(rng::AbstractRNG, d::MVNSampler, n::Integer) =
+Random.rand(rng::AbstractRNG, d::MVNSampler, n::Integer) =
     d.mu .+ d.Q * randn(rng, (length(d.mu), n))
 
 # methods to draw from `MVNSampler`
-Base.rand(d::MVNSampler) = rand(Base.GLOBAL_RNG, d)
-Base.rand(d::MVNSampler, n::Integer) = rand(Base.GLOBAL_RNG, d, n)
+Random.rand(d::MVNSampler) = rand(Random.GLOBAL_RNG, d)
+Random.rand(d::MVNSampler, n::Integer) = rand(Random.GLOBAL_RNG, d, n)
 
 ==(f1::MVNSampler, f2::MVNSampler) =
     (f1.mu == f2.mu) && (f1.Sigma == f2.Sigma) && (f1.Q == f2.Q)

--- a/src/util.jl
+++ b/src/util.jl
@@ -165,10 +165,10 @@ function num_compositions(m, n)
 end
 
 
-"""
+doc"""
 Construct an array consisting of the integer points in the
-(m-1)-dimensional simplex :math:`\{x \mid x_0 + \cdots + x_{m-1} = n
-\}`, or equivalently, the m-part compositions of n, which are listed
+(m-1)-dimensional simplex $\{x \mid x_0 + \cdots + x_{m-1} = n
+\}$, or equivalently, the m-part compositions of n, which are listed
 in lexicographic order. The total number of the points (hence the
 length of the output array) is L = (n+m-1)!/(n!*(m-1)!) (i.e.,
 (n+m-1) choose (m-1)).
@@ -234,10 +234,10 @@ function simplex_grid(m, n)
 end
 
 
-"""
+doc"""
 Return the index of the point x in the lexicographic order of the
-integer points of the (m-1)-dimensional simplex :math:`\{x \mid x_0
-+ \cdots + x_{m-1} = n\}`.
+integer points of the (m-1)-dimensional simplex $\{x \mid x_0
++ \cdots + x_{m-1} = n\}$.
 
 ##### Arguments
 
@@ -343,7 +343,7 @@ the descending sequences of the elements, following
 `InexactError` exception will be thrown, or an incorrect value will be
 returned without warning if overflow occurs during the computation.
 It is the user's responsibility to ensure that the rank of the input
-array fits within the range of `T`; a sufficient condition for it is 
+array fits within the range of `T`; a sufficient condition for it is
 `binomial(BigInt(a[end]), BigInt(length(a))) <= typemax(T)`.
 
 # Arguments

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,5 +1,5 @@
 QuantEcon
 HDF5
 MAT
-JLD
+JLD2
 DataStructures

--- a/test/util.jl
+++ b/test/util.jl
@@ -5,7 +5,7 @@ Utilities for testing QuantEcon
 
 @date: 2014-08-26
 =#
-using HDF5, JLD, MAT
+using HDF5, JLD2, MAT
 
 const test_path = dirname(@__FILE__())
 const data_path = joinpath(test_path, "data")


### PR DESCRIPTION
Enables `using QuantEcon` in v0.7 (some tests do not pass though).