### PR TITLE
Add inv and derivativeinv to some utility functions

### DIFF
--- a/src/QuantEcon.jl
+++ b/src/QuantEcon.jl
@@ -1,6 +1,6 @@
 module QuantEcon
 
-import Base: show, isapprox
+import Base: show, isapprox, inv
 import Statistics: mean, std, var
 using Markdown
 using FFTW
@@ -58,7 +58,7 @@ export
 
 # modeltools
     AbstractUtility, LogUtility, CRRAUtility, CFEUtility, EllipticalUtility,
-    derivative,
+    derivative, derivativeinv, inv,
 
 # gth_solve
     gth_solve,


### PR DESCRIPTION
Adds methods for `u^{-1}` and `du^{-1}` for utility functions where it can be computed by hand.

I have some tests that make sure `u(u^{-1})` returns what we expect, but it wouldn't hurt to have someone glance at the equations to make sure I didn't do anything stupid.