### PR TITLE
DOC: Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,14 @@ matrix:
 notifications:
     email: false
 #script: # use the default script setting which is equivalent to the following
+jobs:
+    include:
+        - stage: "Documentation"
+          script:
+            - julia -e 'using Pkg; Pkg.add("Documenter"); using Documenter'
+            - julia -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'
+            - julia -e 'using Pkg; import QuantEcon; cd(joinpath(dirname(pathof(QuantEcon)), "..")); include(joinpath("docs", "make.jl"))'
+          after_success: skip
 after_success:
     - echo $TRAVIS_JULIA_VERSION
     - julia -e 'using Pkg; import QuantEcon; cd(joinpath(dirname(pathof(QuantEcon)), "..")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
-    - julia -e 'using Pkg; Pkg.add("Documenter")'
-    - julia -e 'using Pkg; import QuantEcon; cd(joinpath(dirname(pathof(QuantEcon)), "..")); include(joinpath("docs", "make.jl"))'

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,7 @@ using Documenter, QuantEcon
 
 makedocs(
     modules = [QuantEcon],
-    format = :html,
+    format = Documenter.HTML(prettyurls = false),
     sitename = "QuantEcon.jl",
     pages = Any[ # Compat: `Any` for 0.4 compat
         "Home" => "index.md",
@@ -18,6 +18,5 @@ deploydocs(
     repo = "github.com/QuantEcon/QuantEcon.jl.git",
     branch = "gh-pages",
     target = "build",
-    julia  = "0.6",
     make = nothing,
 )

--- a/src/util.jl
+++ b/src/util.jl
@@ -236,8 +236,8 @@ end
 
 @doc doc"""
 Return the index of the point x in the lexicographic order of the
-integer points of the (m-1)-dimensional simplex $\{x \mid x_0
-+ \cdots + x_{m-1} = n\}$.
+integer points of the (m-1)-dimensional simplex $\{x \mid x_0 + 
+\cdots + x_{m-1} = n\}$.
 
 ##### Arguments
 


### PR DESCRIPTION
closes #239.

Update keyword value for `Documenter.makedocs` and set `prettyurls` off as in QuantEcon/Games.jl#106.

It seems that we cannot break a math expression in `@doc` block if we use "$$", as I modified in `util.jl`. Otherwise it will trigger documentation rendering failure.