### PR TITLE
Fix bug in random_probvec

### DIFF
--- a/src/markov/random_mc.jl
+++ b/src/markov/random_mc.jl
@@ -229,4 +229,4 @@ end
 random_probvec(k::Integer, m::Integer) = random_probvec(Random.GLOBAL_RNG, k, m)
 
 random_probvec(rng::AbstractRNG, k::Integer) = vec(random_probvec(rng, k, 1))
-random_probvec(k::Integer) = random_probvec(rng, k)
+random_probvec(k::Integer) = random_probvec(Random.GLOBAL_RNG, k)

--- a/test/test_random_mc.jl
+++ b/test/test_random_mc.jl
@@ -81,4 +81,10 @@ using Random
         @test ddps[2].Q == ddps[1].Q
         @test ddps[2].beta == ddps[1].beta
     end
+
+    @testset "Test random_probvec" begin
+        k = 5
+        x = random_probvec(k)
+        @test size(x) == (k,)
+    end
 end  # @testset


### PR DESCRIPTION
Fix the bug:

```jl
QuantEcon.random_probvec(5)
```

```
UndefVarError: rng not defined
```