### PR TITLE
MAINT: Fix deprecation warning on `cholesky`

### DIFF
--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -26,7 +26,7 @@ function MVNSampler(mu::Vector{TM}, Sigma::Matrix{TS}) where {TM<:Real,TS<:Real}
 
     issymmetric(Sigma) || throw(ArgumentError("Sigma must be symmetric"))
 
-    C = cholesky(Symmetric(Sigma, :L), Val(true), check=false)
+    C = cholesky(Symmetric(Sigma, :L), RowMaximum(), check=false)
     A = C.factors
     r = C.rank
     p = invperm(C.piv)

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -6,6 +6,8 @@ import Base: ==
 import LinearAlgebra: BlasReal
 import Random
 
+const Cholesky_RowMaximum = VERSION >= v"1.8.0" ? RowMaximum() : Val(true)
+
 struct MVNSampler{TM<:Real,TS<:Real,TQ<:BlasReal}
     mu::Vector{TM}
     Sigma::Matrix{TS}
@@ -26,7 +28,7 @@ function MVNSampler(mu::Vector{TM}, Sigma::Matrix{TS}) where {TM<:Real,TS<:Real}
 
     issymmetric(Sigma) || throw(ArgumentError("Sigma must be symmetric"))
 
-    C = cholesky(Symmetric(Sigma, :L), RowMaximum(), check=false)
+    C = cholesky(Symmetric(Sigma, :L), Cholesky_RowMaximum, check=false)
     A = C.factors
     r = C.rank
     p = invperm(C.piv)


### PR DESCRIPTION
```
┌ Warning: `cholesky(A::Union{StridedMatrix, RealHermSymComplexHerm{<:Real, <:StridedMatrix}}, ::Val{true}; tol = 0.0, check::Bool = true)` is deprecated, use `cholesky(A, RowMaximum(); tol, check)` instead.
│   caller = ip:0x0
└ @ Core :-1
```