### PR TITLE
fix(kalman)!: return `nothing` instead of `Nothing`

### DIFF
--- a/src/kalman.jl
+++ b/src/kalman.jl
@@ -70,7 +70,7 @@ Set the current state estimate of the Kalman filter.
 function set_state!(k::Kalman, x_hat, Sigma)
     k.cur_x_hat = x_hat
     k.cur_sigma = Sigma
-    Nothing
+    nothing
 end
 
 @doc doc"""
@@ -112,7 +112,7 @@ function prior_to_filtered!(k::Kalman, y)
     M = A / B
     k.cur_x_hat = x_hat + M * (y .- G * x_hat)
     k.cur_sigma = Sigma - M * G * Sigma
-    Nothing
+    nothing
 end
 
 """
@@ -139,7 +139,7 @@ function filtered_to_forecast!(k::Kalman)
     # and then update
     k.cur_x_hat = A * x_hat
     k.cur_sigma = A * Sigma * A' + Q
-    Nothing
+    nothing
 end
 
 """
@@ -161,7 +161,7 @@ update, from one period to the next.
 function update!(k::Kalman, y)
     prior_to_filtered!(k, y)
     filtered_to_forecast!(k)
-    Nothing
+    nothing
 end
 
 


### PR DESCRIPTION
Fixes #364 

Previously the functions returned the type `Nothing`. Now they return the singleton value `nothing`, aligning with Julia conventions.

BREAKING CHANGE: The return value of set_state! and related functions changes from type `Nothing` to value `nothing`. Closes #364