### PR TITLE
Add benchmark suite, with benchmarks for DiscreteDP

### DIFF
--- a/benchmark/.gitignore
+++ b/benchmark/.gitignore
@@ -1,0 +1,1 @@
+/tune.json

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+QuantEcon = "fcd29c91-0bd7-5a09-975d-7ac3f643a60c"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -16,16 +16,17 @@ subgroup of `SUITE`. Currently covered:
 
 ### `ddp` ([`ddp.jl`](ddp.jl))
 
-The suite runs four model cases (random models with a fixed seed):
+The suite runs four model cases (random models, each generated with its
+own fixed-seed RNG so that the cases are independent of one another):
 
 - `dense_n100_m50`: product formulation (`R` of shape `(n, m)`, dense `Q`
   of shape `(n, m, n)`), 100 states and 50 actions — small enough that
   allocations and overhead dominate;
 - `dense_n500_m100`: product formulation, 500 states and 100 actions —
   large enough that BLAS operations dominate;
-- `sa_dense_n500_m100`: the 500 x 100 model in the state-action pair
-  formulation (`R` of length `L`, dense `Q` of shape `(L, n)`), for a
-  direct comparison between the two formulations;
+- `sa_dense_n500_m100`: the same model as `dense_n500_m100`, converted to
+  the state-action pair formulation (`R` of length `L`, dense `Q` of shape
+  `(L, n)`), for a direct comparison between the two formulations;
 - `sa_sparse_n3000_m50_k5`: state-action pair formulation with sparse `Q`,
   3000 states, 50 actions, and 5 nonzero transition probabilities per
   state-action pair.
@@ -41,14 +42,15 @@ For each case, the following are benchmarked:
 | `evaluate_policy` | Policy evaluation (linear solve) |
 | `solve_PFI` | End-to-end `solve` with policy iteration |
 | `solve_MPFI` | End-to-end `solve` with modified policy iteration |
-| `solve_VFI_50iter` | `solve` with value iteration, capped at 50 iterations |
+| `solve_VFI_50iter` | `solve` with value iteration, exactly 50 iterations |
 | `backward_induction_20` | `backward_induction` with 20 periods |
 
 Kernel benchmarks (`bellman_operator`, `s_wise_max`, `RQ_sigma`,
 `evaluate_policy`) use the converged value function and optimal policy as
-inputs so that they are realistic. VFI is capped at `max_iter=50` so that
-the benchmark measures a fixed amount of work independently of convergence
-behavior.
+inputs so that they are realistic. VFI is run with `max_iter=50` and
+`epsilon=0` (an unattainable tolerance), so that the benchmark measures a
+fixed amount of work — exactly 50 iterations — independently of
+convergence behavior.
 
 Note that the suite holds the dense `Q` arrays of the two large cases in
 memory (roughly 0.5 GB in total).

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,125 @@
+# QuantEcon.jl Benchmarks
+
+This directory contains a benchmark suite in the standard
+[BenchmarkTools.jl](https://github.com/JuliaCI/BenchmarkTools.jl) format:
+[`benchmarks.jl`](benchmarks.jl) defines a `BenchmarkGroup` named `SUITE`,
+which can be run standalone or through
+[PkgBenchmark.jl](https://github.com/JuliaCI/PkgBenchmark.jl).
+
+Each benchmarked module has its own file, included by `benchmarks.jl` as a
+subgroup of `SUITE`. Currently covered:
+
+- [`ddp.jl`](ddp.jl): `DiscreteDP` (`src/markov/ddp.jl`), under
+  `SUITE["ddp"]`.
+
+## What is benchmarked
+
+### `ddp` ([`ddp.jl`](ddp.jl))
+
+The suite runs four model cases (random models with a fixed seed):
+
+- `dense_n100_m50`: product formulation (`R` of shape `(n, m)`, dense `Q`
+  of shape `(n, m, n)`), 100 states and 50 actions — small enough that
+  allocations and overhead dominate;
+- `dense_n500_m100`: product formulation, 500 states and 100 actions —
+  large enough that BLAS operations dominate;
+- `sa_dense_n500_m100`: the 500 x 100 model in the state-action pair
+  formulation (`R` of length `L`, dense `Q` of shape `(L, n)`), for a
+  direct comparison between the two formulations;
+- `sa_sparse_n3000_m50_k5`: state-action pair formulation with sparse `Q`,
+  3000 states, 50 actions, and 5 nonzero transition probabilities per
+  state-action pair.
+
+For each case, the following are benchmarked:
+
+| Key | Description |
+|:----|:------------|
+| `constructor` | `DiscreteDP` construction (input verification, `a_indptr` generation) |
+| `bellman_operator` | One application of `bellman_operator!` |
+| `s_wise_max` | State-wise maximization kernel `s_wise_max!` (internal) |
+| `RQ_sigma` | Extraction of `R_sigma`, `Q_sigma` for a policy |
+| `evaluate_policy` | Policy evaluation (linear solve) |
+| `solve_PFI` | End-to-end `solve` with policy iteration |
+| `solve_MPFI` | End-to-end `solve` with modified policy iteration |
+| `solve_VFI_50iter` | `solve` with value iteration, capped at 50 iterations |
+| `backward_induction_20` | `backward_induction` with 20 periods |
+
+Kernel benchmarks (`bellman_operator`, `s_wise_max`, `RQ_sigma`,
+`evaluate_policy`) use the converged value function and optimal policy as
+inputs so that they are realistic. VFI is capped at `max_iter=50` so that
+the benchmark measures a fixed amount of work independently of convergence
+behavior.
+
+Note that the suite holds the dense `Q` arrays of the two large cases in
+memory (roughly 0.5 GB in total).
+
+## Running the suite standalone
+
+From the repository root, set up the benchmark environment once:
+
+```
+julia --project=benchmark -e 'using Pkg; Pkg.develop(path="."); Pkg.instantiate()'
+```
+
+Then run the whole suite (takes a few minutes):
+
+```
+julia --project=benchmark benchmark/benchmarks.jl
+```
+
+To run interactively, e.g., only a subset:
+
+```julia
+julia> include("benchmark/benchmarks.jl");
+
+julia> run(SUITE["ddp"]["dense_n500_m100"]["bellman_operator"])
+```
+
+## Running with PkgBenchmark.jl
+
+Install PkgBenchmark in your default environment, then, with this package
+active (e.g. `julia --project=.`):
+
+```julia
+using PkgBenchmark
+
+results = benchmarkpkg("QuantEcon")
+export_markdown("results.md", results)
+```
+
+### Comparing two commits
+
+To evaluate the performance change of a target commit (or branch) relative
+to a baseline:
+
+```julia
+jud = judge("QuantEcon", "<target>", "<baseline>")
+export_markdown("judgement.md", jud)
+```
+
+For example, to compare the current state of `master` against the previous
+commit:
+
+```julia
+jud = judge("QuantEcon", "master", "master~1")
+```
+
+Display the judgment summary:
+
+```julia
+julia> show(PkgBenchmark.benchmarkgroup(jud))
+```
+
+and the timing estimates of each side:
+
+```julia
+julia> show(jud.baseline_results.benchmarkgroup)
+
+julia> show(jud.target_results.benchmarkgroup)
+```
+
+Note that `judge` checks out and runs each commit, so uncommitted changes
+in the working tree are not included.
+
+For comprehensive usage details, refer to the
+[PkgBenchmark documentation](https://juliaci.github.io/PkgBenchmark.jl/stable).

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,28 @@
+#=
+Benchmark suite for QuantEcon.jl
+
+Defines `SUITE` in the standard BenchmarkTools format, usable with
+PkgBenchmark.jl or AirspeedVelocity.jl.
+
+To run standalone:
+
+    julia --project=benchmark -e 'using Pkg; Pkg.develop(path="."); Pkg.instantiate()'
+    julia --project=benchmark benchmark/benchmarks.jl
+
+Each benchmarked module has its own file defining a `BenchmarkGroup`,
+included below as a subgroup of `SUITE`.
+=#
+using BenchmarkTools
+
+const SUITE = BenchmarkGroup()
+
+SUITE["ddp"] = include("ddp.jl")
+
+#= Standalone execution =#
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    tune!(SUITE)
+    results = run(SUITE; verbose=true)
+    show(IOContext(stdout, :compact => false), MIME"text/plain"(), results)
+    println()
+end

--- a/benchmark/ddp.jl
+++ b/benchmark/ddp.jl
@@ -85,7 +85,10 @@ function add_ddp_benchmarks!(grp, ddp)
     grp["evaluate_policy"] = @benchmarkable evaluate_policy($ddp, $sigma)
     grp["solve_PFI"] = @benchmarkable solve($ddp, PFI)
     grp["solve_MPFI"] = @benchmarkable solve($ddp, MPFI)
-    grp["solve_VFI_50iter"] = @benchmarkable solve($ddp, VFI; max_iter=50)
+    # epsilon=0 makes the tolerance unattainable, so that exactly max_iter
+    # iterations are performed
+    grp["solve_VFI_50iter"] =
+        @benchmarkable solve($ddp, VFI; max_iter=50, epsilon=0.0)
     grp["backward_induction_20"] = @benchmarkable backward_induction($ddp, 20)
     return grp
 end
@@ -94,26 +97,29 @@ end
 
 suite = BenchmarkGroup()
 
-seed = 1234
-rng = MersenneTwister(seed)
+# A fresh generator per case, so that adding or reordering cases does not
+# alter the model data of the other cases
+new_rng() = MersenneTwister(1234)
 
 # Product formulation, two sizes: allocation/overhead-dominated (small)
 # and BLAS-dominated (large)
-for (n, m) in [(100, 50), (500, 100)]
-    ddp = random_ddp(rng, n, m)
-    grp = suite["dense_n$(n)_m$(m)"] = BenchmarkGroup()
+ddp_dense_small = random_ddp(new_rng(), 100, 50)
+ddp_dense_large = random_ddp(new_rng(), 500, 100)
+for (label, ddp) in [("dense_n100_m50", ddp_dense_small),
+                     ("dense_n500_m100", ddp_dense_large)]
+    grp = suite[label] = BenchmarkGroup()
     grp["constructor"] =
         @benchmarkable DiscreteDP($(ddp.R), $(ddp.Q), $(ddp.beta))
     add_ddp_benchmarks!(grp, ddp)
 end
 
-# State-action pair formulation with dense Q: the large product-form model
-# converted, for a direct comparison between the two formulations
-let (n, m) = (500, 100)
-    ddp = random_ddp(rng, n, m)
+# State-action pair formulation with dense Q: the same model as
+# dense_n500_m100, converted, for a direct comparison between the two
+# formulations
+let ddp = ddp_dense_large
     R_sa, Q_sa, s_indices, a_indices = sa_pair_arrays(ddp)
     ddp_sa = DiscreteDP(R_sa, Q_sa, ddp.beta, s_indices, a_indices)
-    grp = suite["sa_dense_n$(n)_m$(m)"] = BenchmarkGroup()
+    grp = suite["sa_dense_n500_m100"] = BenchmarkGroup()
     grp["constructor"] = @benchmarkable DiscreteDP(
         $R_sa, $Q_sa, $(ddp.beta), $s_indices, $a_indices
     )
@@ -122,7 +128,7 @@ end
 
 # State-action pair formulation with sparse Q
 let (n, m, k) = (3000, 50, 5)
-    ddp_sp = random_sparse_sa_ddp(rng, n, m, k)
+    ddp_sp = random_sparse_sa_ddp(new_rng(), n, m, k)
     grp = suite["sa_sparse_n$(n)_m$(m)_k$(k)"] = BenchmarkGroup()
     grp["constructor"] = @benchmarkable DiscreteDP(
         $(ddp_sp.R), $(ddp_sp.Q), $(ddp_sp.beta),

--- a/benchmark/ddp.jl
+++ b/benchmark/ddp.jl
@@ -1,0 +1,134 @@
+#=
+Benchmarks for markov/ddp.jl (DiscreteDP)
+
+Covers the main computational kernels and end-to-end solves, for both the
+product formulation (dense R, Q) and the state-action pair formulation
+(with dense and sparse Q). Kernel benchmarks use the converged value
+function and optimal policy as inputs so that they are realistic.
+
+VFI is capped at `max_iter=50` so that the benchmark measures a fixed
+amount of work independently of convergence behavior; PFI and MPFI
+converge in a few iterations and are benchmarked end-to-end.
+=#
+using QuantEcon
+using BenchmarkTools
+using Random
+using SparseArrays
+
+#= Model generators =#
+
+# Random DiscreteDP in product form: R of shape (n, m), Q of shape (n, m, n)
+function random_ddp(rng, n, m; beta=0.95)
+    R = rand(rng, n, m)
+    Q = rand(rng, n, m, n)
+    Q ./= sum(Q, dims=3)
+    return DiscreteDP(R, Q, beta)
+end
+
+# Arrays for the same model in state-action pair form, with the pairs
+# sorted lexicographically (action varying fastest)
+function sa_pair_arrays(ddp::DiscreteDP)
+    n, m = size(ddp.R)
+    s_indices = repeat(1:n, inner=m)
+    a_indices = repeat(1:m, outer=n)
+    R_sa = vec(permutedims(ddp.R))
+    Q_sa = reshape(permutedims(ddp.Q, (2, 1, 3)), n * m, n)
+    return R_sa, Q_sa, s_indices, a_indices
+end
+
+# Random DiscreteDP in state-action pair form with sparse Q: all m actions
+# feasible at every state, k nonzero transition probabilities per pair
+function random_sparse_sa_ddp(rng, n, m, k; beta=0.95)
+    L = n * m
+    s_indices = repeat(1:n, inner=m)
+    a_indices = repeat(1:m, outer=n)
+    R = rand(rng, L)
+    rows = Vector{Int}(undef, L * k)
+    cols = Vector{Int}(undef, L * k)
+    vals = Vector{Float64}(undef, L * k)
+    chosen = Vector{Int}(undef, k)
+    idx = 0
+    for i in 1:L
+        for j in 1:k  # draw k distinct destination states
+            c = rand(rng, 1:n)
+            while c in view(chosen, 1:j-1)
+                c = rand(rng, 1:n)
+            end
+            chosen[j] = c
+        end
+        w = rand(rng, k)
+        w ./= sum(w)
+        for j in 1:k
+            idx += 1
+            rows[idx], cols[idx], vals[idx] = i, chosen[j], w[j]
+        end
+    end
+    Q = sparse(rows, cols, vals, L, n)
+    return DiscreteDP(R, Q, beta, s_indices, a_indices)
+end
+
+#= Benchmarks common to all formulations =#
+
+function add_ddp_benchmarks!(grp, ddp)
+    # kernel inputs at the solution, for realistic values
+    res = solve(ddp, PFI)
+    v, sigma = res.v, res.sigma
+    vals = ddp.R + ddp.beta * (ddp.Q * v)
+    Tv = similar(v)
+    sigma_buf = similar(sigma)
+
+    grp["bellman_operator"] =
+        @benchmarkable bellman_operator!($ddp, $v, $Tv, $sigma_buf)
+    grp["s_wise_max"] =
+        @benchmarkable QuantEcon.s_wise_max!($ddp, $vals, $Tv, $sigma_buf)
+    grp["RQ_sigma"] = @benchmarkable RQ_sigma($ddp, $sigma)
+    grp["evaluate_policy"] = @benchmarkable evaluate_policy($ddp, $sigma)
+    grp["solve_PFI"] = @benchmarkable solve($ddp, PFI)
+    grp["solve_MPFI"] = @benchmarkable solve($ddp, MPFI)
+    grp["solve_VFI_50iter"] = @benchmarkable solve($ddp, VFI; max_iter=50)
+    grp["backward_induction_20"] = @benchmarkable backward_induction($ddp, 20)
+    return grp
+end
+
+#= Suite =#
+
+suite = BenchmarkGroup()
+
+seed = 1234
+rng = MersenneTwister(seed)
+
+# Product formulation, two sizes: allocation/overhead-dominated (small)
+# and BLAS-dominated (large)
+for (n, m) in [(100, 50), (500, 100)]
+    ddp = random_ddp(rng, n, m)
+    grp = suite["dense_n$(n)_m$(m)"] = BenchmarkGroup()
+    grp["constructor"] =
+        @benchmarkable DiscreteDP($(ddp.R), $(ddp.Q), $(ddp.beta))
+    add_ddp_benchmarks!(grp, ddp)
+end
+
+# State-action pair formulation with dense Q: the large product-form model
+# converted, for a direct comparison between the two formulations
+let (n, m) = (500, 100)
+    ddp = random_ddp(rng, n, m)
+    R_sa, Q_sa, s_indices, a_indices = sa_pair_arrays(ddp)
+    ddp_sa = DiscreteDP(R_sa, Q_sa, ddp.beta, s_indices, a_indices)
+    grp = suite["sa_dense_n$(n)_m$(m)"] = BenchmarkGroup()
+    grp["constructor"] = @benchmarkable DiscreteDP(
+        $R_sa, $Q_sa, $(ddp.beta), $s_indices, $a_indices
+    )
+    add_ddp_benchmarks!(grp, ddp_sa)
+end
+
+# State-action pair formulation with sparse Q
+let (n, m, k) = (3000, 50, 5)
+    ddp_sp = random_sparse_sa_ddp(rng, n, m, k)
+    grp = suite["sa_sparse_n$(n)_m$(m)_k$(k)"] = BenchmarkGroup()
+    grp["constructor"] = @benchmarkable DiscreteDP(
+        $(ddp_sp.R), $(ddp_sp.Q), $(ddp_sp.beta),
+        $(repeat(1:n, inner=m)), $(repeat(1:m, outer=n))
+    )
+    add_ddp_benchmarks!(grp, ddp_sp)
+end
+
+suite


### PR DESCRIPTION
This PR adds a benchmark suite in the standard [BenchmarkTools.jl](https://github.com/JuliaCI/BenchmarkTools.jl) format, following the layout used in [ContinuousDPs.jl](https://github.com/QuantEcon/ContinuousDPs.jl/tree/main/benchmark) and [GameTheory.jl](https://github.com/QuantEcon/GameTheory.jl/tree/main/benchmark): `benchmark/benchmarks.jl` defines a `BenchmarkGroup` named `SUITE`, runnable standalone or through [PkgBenchmark.jl](https://github.com/JuliaCI/PkgBenchmark.jl). Each benchmarked module has its own file, included as a subgroup of `SUITE`; currently `benchmark/ddp.jl` covers `DiscreteDP` (`src/markov/ddp.jl`) under `SUITE["ddp"]`.

The purpose is to establish a performance baseline ahead of planned optimization work on `src/markov/ddp.jl` (see #118 and #124): with this in place, the performance effect of each subsequent change can be evaluated with `PkgBenchmark.judge("QuantEcon", target, baseline)`.

**What is benchmarked**

Four model cases (random models with a fixed seed):

- `dense_n100_m50`, `dense_n500_m100`: product formulation (dense `R`, `Q`), an allocation/overhead-dominated size and a BLAS-dominated size;
- `sa_dense_n500_m100`: the large model in state-action pair formulation with dense `Q`, for a direct comparison between the two formulations;
- `sa_sparse_n3000_m50_k5`: state-action pair formulation with sparse `Q` (5 nonzero transition probabilities per pair).

For each case: `constructor`, `bellman_operator`, `s_wise_max` (internal kernel), `RQ_sigma`, `evaluate_policy`, `solve_PFI`, `solve_MPFI`, `solve_VFI_50iter`, and `backward_induction_20`. Kernel benchmarks use the converged value function and optimal policy as inputs so that they are realistic; VFI is capped at `max_iter=50` so that it measures a fixed amount of work independently of convergence behavior.

**Notes**

- Setup and usage (standalone and via PkgBenchmark) are documented in `benchmark/README.md`.
- The suite holds the dense `Q` arrays of the two large cases in memory (roughly 0.5 GB in total).
- `benchmark/Manifest.toml` is already covered by the root `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
