### PR TITLE
ENH: Store s_indices; add num_sa_pairs, to_sa_pair_form, to_product_form

### DIFF
--- a/src/QuantEcon.jl
+++ b/src/QuantEcon.jl
@@ -131,6 +131,7 @@ export
     DiscreteDP, VFI, PFI, MPFI, solve, RQ_sigma,
     evaluate_policy, bellman_operator, compute_greedy,
     bellman_operator!, compute_greedy!, num_states, backward_induction,
+    num_sa_pairs, to_sa_pair_form, to_product_form,
 
 # zeros / optimization
     bisect, brenth, brent, ridder, expand_bracket, divide_bracket,

--- a/src/markov/ddp.jl
+++ b/src/markov/ddp.jl
@@ -38,7 +38,7 @@ DiscreteDP type for specifying parameters for discrete dynamic programming model
   state-action pair formulation with sparse `Q`, the data are stored
   internally in transposed (states-tomorrow x sa-pairs) order and `Q` is
   the lazy `Transpose` view of them, with the documented shape `(L, n)`.
-- `beta::Float64`: Discount factor.
+- `beta::Real`: Discount factor.
 - `s_indices::Vector{Tind}`: State indices, sorted. Empty unless using SA
   formulation.
 - `a_indices::Vector{Tind}`: Action indices. Empty unless using SA formulation.
@@ -201,7 +201,7 @@ model using dense matrix formulation.
 
 - `R::Array{T,NR}`: Reward array.
 - `Q::AbstractArray{T,NQ}`: Transition probability array.
-- `beta::Float64`: Discount factor.
+- `beta::Real`: Discount factor.
 
 # Returns
 
@@ -223,7 +223,7 @@ model using state-action pair formulation.
 
 - `R::AbstractArray{T,NR}`: Reward array.
 - `Q::AbstractArray{T,NQ}`: Transition probability array; may be sparse.
-- `beta::Float64`: Discount factor.
+- `beta::Real`: Discount factor.
 - `s_indices::Vector{Tind}`: State indices.
 - `a_indices::Vector{Tind}`: Action indices.
 
@@ -345,19 +345,50 @@ function to_product_form(ddp::DDPsa{T}) where T
     m = maximum(ddp.a_indices)
     L = num_sa_pairs(ddp)
     R = fill(convert(T, -Inf), n, m)
-    Q = zeros(T, n, m, n)
-    Q_dense = Matrix(ddp.Q)
     for i in 1:L
-        s, a = ddp.s_indices[i], ddp.a_indices[i]
-        R[s, a] = ddp.R[i]
-        for j in 1:n
-            Q[s, a, j] = Q_dense[i, j]
-        end
+        R[ddp.s_indices[i], ddp.a_indices[i]] = ddp.R[i]
     end
+    Q = zeros(T, n, m, n)
+    _fill_product_Q!(Q, ddp.s_indices, ddp.a_indices, ddp.Q)
     return DiscreteDP(R, Q, ddp.beta)
 end
 
 to_product_form(ddp::DDP) = ddp
+
+# fill the rows Q[s_indices[i], a_indices[i], :] of the product-form array
+# from row i of the sa-form Q_sa, without materializing a dense copy: for
+# the transposed sparse internal storage, iterate the nonzeros of column i
+# of the parent
+function _fill_product_Q!(
+        Q::AbstractArray, s_indices::AbstractVector,
+        a_indices::AbstractVector,
+        Q_sa::Transpose{<:Any,<:SparseMatrixCSC}
+    )
+    B = parent(Q_sa)
+    rows = rowvals(B)
+    vals = nonzeros(B)
+    for i in eachindex(s_indices, a_indices)
+        s, a = s_indices[i], a_indices[i]
+        for k in nzrange(B, i)
+            Q[s, a, rows[k]] = vals[k]
+        end
+    end
+    return Q
+end
+
+function _fill_product_Q!(
+        Q::AbstractArray, s_indices::AbstractVector,
+        a_indices::AbstractVector, Q_sa::AbstractMatrix
+    )
+    n = size(Q_sa, 2)
+    for i in eachindex(s_indices, a_indices)
+        s, a = s_indices[i], a_indices[i]
+        for j in 1:n
+            Q[s, a, j] = Q_sa[i, j]
+        end
+    end
+    return Q
+end
 
 
 abstract type DDPAlgorithm end

--- a/src/markov/ddp.jl
+++ b/src/markov/ddp.jl
@@ -39,6 +39,8 @@ DiscreteDP type for specifying parameters for discrete dynamic programming model
   internally in transposed (states-tomorrow x sa-pairs) order and `Q` is
   the lazy `Transpose` view of them, with the documented shape `(L, n)`.
 - `beta::Float64`: Discount factor.
+- `s_indices::Vector{Tind}`: State indices, sorted. Empty unless using SA
+  formulation.
 - `a_indices::Vector{Tind}`: Action indices. Empty unless using SA formulation.
 - `a_indptr::Vector{Tind}`: Action index pointers. Empty unless using SA formulation.
 
@@ -47,6 +49,7 @@ mutable struct DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind,TQ<:AbstractArray{T,NQ}
     R::Array{T,NR}                     # Reward Array
     Q::TQ                     # Transition Probability Array
     beta::Tbeta                        # Discount Factor
+    s_indices::Vector{Tind}  # State Indices
     a_indices::Vector{Tind}  # Action Indices
     a_indptr::Vector{Tind}   # Action Index Pointers
 
@@ -83,10 +86,12 @@ mutable struct DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind,TQ<:AbstractArray{T,NQ}
         end
 
         # here the indices and indptr are empty.
+        _s_indices = Vector{Int}()
         _a_indices = Vector{Int}()
         a_indptr = Vector{Int}()
 
-        new{T,NQ,NR,Tbeta,Tind,typeof(Q)}(R, Q, beta, _a_indices, a_indptr)
+        new{T,NQ,NR,Tbeta,Tind,typeof(Q)}(R, Q, beta, _s_indices, _a_indices,
+                                          a_indptr)
     end
 
     # Note: We left R, Q as type Array to produce more helpful error message with regards to shape.
@@ -132,6 +137,7 @@ mutable struct DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind,TQ<:AbstractArray{T,NQ}
 
         if _has_sorted_sa_indices(s_indices, a_indices)
             a_indptr = Array{Int64}(undef, num_states + 1)
+            _s_indices = copy(s_indices)
             _a_indices = copy(a_indices)
             _generate_a_indptr!(num_states, s_indices, a_indptr)
         else
@@ -146,6 +152,12 @@ mutable struct DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind,TQ<:AbstractArray{T,NQ}
 
             R = R[as_ptr.nzval]
             Q = Q[as_ptr.nzval, :]
+
+            # reconstruct the sorted state indices from a_indptr
+            _s_indices = Vector{Int}(undef, num_sa_pairs)
+            for i in 1:num_states, j in a_indptr[i]:(a_indptr[i+1]-1)
+                _s_indices[j] = i
+            end
         end
 
         # check feasibility
@@ -158,6 +170,7 @@ mutable struct DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind,TQ<:AbstractArray{T,NQ}
         end
 
         # indices
+        _s_indices = Vector{Tind}(_s_indices)
         _a_indices = Vector{Tind}(_a_indices)
         a_indptr = Vector{Tind}(a_indptr)
 
@@ -173,7 +186,8 @@ mutable struct DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind,TQ<:AbstractArray{T,NQ}
             Q = transpose(sparse(transpose(Q)))
         end
 
-        new{T,NQ,NR,Tbeta,Tind,typeof(Q)}(R, Q, beta, _a_indices, a_indptr)
+        new{T,NQ,NR,Tbeta,Tind,typeof(Q)}(R, Q, beta, _s_indices, _a_indices,
+                                          a_indptr)
     end
 end
 
@@ -238,6 +252,112 @@ const DDPsa{T,Tbeta,Tind,TQ} =  DiscreteDP{T,2,1,Tbeta,Tind,TQ}
 
 num_states(ddp::DDP) = size(ddp.R, 1)
 num_states(ddp::DDPsa) = size(ddp.Q, 2)
+
+"""
+    num_sa_pairs(ddp)
+
+Number of feasible state-action pairs: for the state-action pair
+formulation, the number of pairs given at construction; for the product
+formulation, the number of pairs with a finite reward.
+
+# Arguments
+
+- `ddp::DiscreteDP`: Object that contains the model parameters.
+
+# Returns
+
+- `L::Int`: Number of feasible state-action pairs.
+
+"""
+num_sa_pairs(ddp::DDP) = count(>(-Inf), ddp.R)
+num_sa_pairs(ddp::DDPsa) = length(ddp.R)
+
+#-----------------#
+#-Form Converters-#
+#-----------------#
+
+"""
+    to_sa_pair_form(ddp; sparse=true)
+
+Convert `ddp` to the equivalent `DiscreteDP` in state-action pair form.
+The feasible pairs are those with a finite reward, enumerated in
+lexicographic order. An instance already in state-action pair form is
+returned unmodified.
+
+# Arguments
+
+- `ddp::DiscreteDP`: Object that contains the model parameters.
+- `;sparse::Bool(true)`: Whether to store the transition probability
+  array of the converted instance as a sparse matrix.
+
+# Returns
+
+- `ddp_sa::DiscreteDP`: The equivalent `DiscreteDP` in state-action pair
+  form.
+
+"""
+function to_sa_pair_form(ddp::DDP{T}; sparse::Bool=true) where T
+    n, m = size(ddp.R)
+    L = num_sa_pairs(ddp)
+    s_indices = Vector{Int}(undef, L)
+    a_indices = Vector{Int}(undef, L)
+    R = Vector{T}(undef, L)
+    Q = Matrix{T}(undef, L, n)
+    k = 0
+    for s in 1:n, a in 1:m
+        if ddp.R[s, a] > -Inf
+            k += 1
+            s_indices[k] = s
+            a_indices[k] = a
+            R[k] = ddp.R[s, a]
+            for j in 1:n
+                Q[k, j] = ddp.Q[s, a, j]
+            end
+        end
+    end
+    Q_out = sparse ? SparseArrays.sparse(Q) : Q
+    return DiscreteDP(R, Q_out, ddp.beta, s_indices, a_indices)
+end
+
+to_sa_pair_form(ddp::DDPsa; sparse::Bool=true) = ddp
+
+"""
+    to_product_form(ddp)
+
+Convert `ddp` to the equivalent `DiscreteDP` in product form, with a
+reward array of shape `(n, m)` and a transition probability array of
+shape `(n, m, n)`, where `m` is the largest action index. Infeasible
+pairs are assigned a reward of `-Inf` and a zero vector of transition
+probabilities. An instance already in product form is returned
+unmodified.
+
+# Arguments
+
+- `ddp::DiscreteDP`: Object that contains the model parameters.
+
+# Returns
+
+- `ddp_pf::DiscreteDP`: The equivalent `DiscreteDP` in product form.
+
+"""
+function to_product_form(ddp::DDPsa{T}) where T
+    n = num_states(ddp)
+    m = maximum(ddp.a_indices)
+    L = num_sa_pairs(ddp)
+    R = fill(convert(T, -Inf), n, m)
+    Q = zeros(T, n, m, n)
+    Q_dense = Matrix(ddp.Q)
+    for i in 1:L
+        s, a = ddp.s_indices[i], ddp.a_indices[i]
+        R[s, a] = ddp.R[i]
+        for j in 1:n
+            Q[s, a, j] = Q_dense[i, j]
+        end
+    end
+    return DiscreteDP(R, Q, ddp.beta)
+end
+
+to_product_form(ddp::DDP) = ddp
 
 
 abstract type DDPAlgorithm end

--- a/src/markov/ddp.jl
+++ b/src/markov/ddp.jl
@@ -328,8 +328,10 @@ Convert `ddp` to the equivalent `DiscreteDP` in product form, with a
 reward array of shape `(n, m)` and a transition probability array of
 shape `(n, m, n)`, where `m` is the largest action index. Infeasible
 pairs are assigned a reward of `-Inf` and a zero vector of transition
-probabilities. An instance already in product form is returned
-unmodified.
+probabilities; when such pairs exist, the reward element type must be
+able to represent `-Inf` (a floating point type, or a `Rational`, for
+which the sentinel is `-1//0`). An instance already in product form is
+returned unmodified.
 
 # Arguments
 
@@ -344,7 +346,21 @@ function to_product_form(ddp::DDPsa{T}) where T
     n = num_states(ddp)
     m = maximum(ddp.a_indices)
     L = num_sa_pairs(ddp)
-    R = fill(convert(T, -Inf), n, m)
+    R = Matrix{T}(undef, n, m)
+    if L < n * m
+        # some product-form cells are infeasible: fill with the -Inf
+        # sentinel, representable for floating point types and for
+        # Rationals (as -1//0)
+        R_neg_inf = try
+            convert(T, -Inf)
+        catch
+            throw(ArgumentError("the model has infeasible state-action " *
+                "pairs, which cannot be represented with reward eltype " *
+                "$T (no -Inf available); convert the rewards to a " *
+                "floating point or Rational eltype first"))
+        end
+        fill!(R, R_neg_inf)
+    end
     for i in 1:L
         R[ddp.s_indices[i], ddp.a_indices[i]] = ddp.R[i]
     end

--- a/test/test_ddp.jl
+++ b/test/test_ddp.jl
@@ -489,6 +489,37 @@ Tests for markov/ddp.jl
             end
             @test isapprox(solve(_d, PFI).v, sol.v)
         end
+
+        @testset "non-floating reward eltypes" begin
+            # full action grid: no -Inf sentinel is needed, and the
+            # eltype is preserved
+            R_int = [1 2; 3 4]
+            Q_int = zeros(Int, 2, 2, 2)
+            Q_int[:, :, 1] .= 1
+            ddp_int = DiscreteDP(R_int, Q_int, 1//2)
+            ddp_int_rt = to_product_form(to_sa_pair_form(ddp_int,
+                                                         sparse=false))
+            @test ddp_int_rt.R == R_int
+            @test eltype(ddp_int_rt.R) == Int
+            @test ddp_int_rt.Q == Q_int
+
+            # Rational rewards: -1//0 is an exact -Inf sentinel, so
+            # partial action grids round-trip exactly
+            R_r = [1//2, 1//1, 1//3]
+            Q_r = [1//2 1//2; 0//1 1//1; 0//1 1//1]
+            ddp_r = DiscreteDP(R_r, Q_r, 19//20, [1, 1, 2], [1, 2, 1])
+            ddp_r_pf = to_product_form(ddp_r)
+            @test ddp_r_pf.R[2, 2] == -1//0
+            @test num_sa_pairs(ddp_r_pf) == 3
+            ddp_r_rt = to_sa_pair_form(ddp_r_pf, sparse=false)
+            @test ddp_r_rt.R == R_r
+            @test Matrix(ddp_r_rt.Q) == Q_r
+
+            # Int rewards with a partial action grid: informative error
+            ddp_int_partial = DiscreteDP([1, 2, 3], [1 0; 0 1; 0 1],
+                                         1//2, [1, 1, 2], [1, 2, 1])
+            @test_throws ArgumentError to_product_form(ddp_int_partial)
+        end
     end
 
     @testset "regression tests for fixed bugs" begin

--- a/test/test_ddp.jl
+++ b/test/test_ddp.jl
@@ -407,6 +407,90 @@ Tests for markov/ddp.jl
         # @test_throws ArgumentError DiscreteDP(R_sa, Q_sa, beta, s_indices, a_indices)
     end
 
+    @testset "sa-pair sorting and stored indices" begin
+        # sorted fixtures
+        _s_ind = [1, 1, 2]
+        _a_ind = [1, 2, 1]
+        _a_indptr = [1, 3, 4]
+        _R = [0.0, 1.0, 2.0]
+        _Q = [1.0 0.0; 0.5 0.5; 0.0 1.0]
+        # shuffled variants of the same model
+        _s_ind_sh = [1, 2, 1]
+        _a_ind_sh = [1, 1, 2]
+        _R_sh = [0.0, 2.0, 1.0]
+        _Q_sh = [1.0 0.0; 0.0 1.0; 0.5 0.5]
+
+        for (R_i, Q_i, s_i, a_i) in ((_R, _Q, _s_ind, _a_ind),
+                                     (_R_sh, _Q_sh, _s_ind_sh, _a_ind_sh))
+            for Q_c in (Q_i, sparse(Q_i))
+                _ddp = DiscreteDP(R_i, Q_c, beta, s_i, a_i)
+                @test _ddp.s_indices == _s_ind
+                @test _ddp.a_indices == _a_ind
+                @test _ddp.a_indptr == _a_indptr
+                @test _ddp.R == _R
+                @test Matrix(_ddp.Q) == _Q
+            end
+        end
+    end
+
+    @testset "num_sa_pairs and form converters" begin
+        _n, _m = 3, 2
+        _R = [0.0 1.0; 1.0 0.0; -Inf 1.0]
+        _Q = fill(1/3, (_n, _m, _n))
+        _Q[1, 1, 1] = 0.0
+        _Q[1, 1, 2] = 2/3
+        _ddp = DiscreteDP(_R, _Q, beta)
+        @test num_sa_pairs(_ddp) == 5
+
+        # expected sa-pair arrays (lexicographic pair order)
+        sa_R = [0.0, 1.0, 1.0, 0.0, 1.0]
+        sa_Q = fill(1/3, (5, _n))
+        sa_Q[1, 1] = 0.0
+        sa_Q[1, 2] = 2/3
+
+        ddp_sa = to_sa_pair_form(_ddp)
+        ddp_sa2 = to_sa_pair_form(ddp_sa)
+        ddp_sa3 = to_sa_pair_form(_ddp, sparse=false)
+        ddp_pf2 = to_product_form(ddp_sa)
+        ddp_pf3 = to_product_form(ddp_sa3)
+        ddp_pf4 = to_product_form(_ddp)
+
+        # identity on instances already in the target form
+        @test ddp_sa2 === ddp_sa
+        @test ddp_pf4 === _ddp
+
+        @test issparse(ddp_sa.Q)
+        @test !issparse(ddp_sa3.Q)
+        for _d in (ddp_sa, ddp_sa3)
+            @test _d.R == sa_R
+            @test Matrix(_d.Q) == sa_Q
+            @test _d.beta == beta
+            @test _d.s_indices == [1, 1, 2, 2, 3]
+            @test _d.a_indices == [1, 2, 1, 2, 2]
+            @test num_sa_pairs(_d) == 5
+        end
+
+        # the infeasible pair gets reward -Inf and a zero probability row
+        funky_Q = fill(1/3, (_n, _m, _n))
+        funky_Q[1, 1, 1] = 0.0
+        funky_Q[1, 1, 2] = 2/3
+        funky_Q[3, 1, :] .= 0.0
+        for _d in (ddp_pf2, ddp_pf3)
+            @test _d.R == _R
+            @test _d.Q == funky_Q
+            @test _d.beta == beta
+        end
+
+        # all representations solve to the same solution
+        sol = solve(_ddp, PFI)
+        for _d in (ddp_sa, ddp_sa3, ddp_pf2, ddp_pf3)
+            for Algo in (VFI, PFI, MPFI)
+                @test solve(_d, Algo).sigma == sol.sigma
+            end
+            @test isapprox(solve(_d, PFI).v, sol.v)
+        end
+    end
+
     @testset "regression tests for fixed bugs" begin
         @testset "solve must not mutate v_init" begin
             for ddp_item in ddp0_collection, Algo in (VFI, PFI, MPFI)


### PR DESCRIPTION
This PR synchronizes three `DiscreteDP` features from QuantEcon.py (part of the ongoing cross-implementation alignment; see QuantEcon/QuantEcon.py#855/#857 for the reverse direction). It builds on the just-merged #388.

**Changes**

- **`s_indices` is now stored on the instance** (a new field, empty for the product form like `a_indices`/`a_indptr` already are). For unsorted input the sorted state indices are reconstructed from `a_indptr`, exactly as in QuantEcon.py. This is a struct-layout change: code constructing `DiscreteDP` through the public constructors is unaffected.
- **`num_sa_pairs(ddp)`** (new, exported): the number of pairs given at construction for the sa form; the number of finite-reward pairs for the product form. Matches the Python attribute's definition.
- **`to_sa_pair_form(ddp; sparse=true)` and `to_product_form(ddp)`** (new, exported): direct ports of the Python converters. Product→sa enumerates the finite-reward pairs in lexicographic order (sparse `Q` by default, which lands in the #388 transposed storage automatically); sa→product assigns infeasible pairs a reward of `-Inf` and zero transition probabilities. Instances already in the target form are returned unmodified. Practical relevance: per the representation analysis on the benchmark suite, models with few transitions per pair should be solved in the sparse sa form (up to ~30x on VI/MPI at low fill), and these converters are the migration path from naturally product-form model definitions.

**Tests**: ports of QuantEcon.py's `test_ddp_sorting` (sorted/unsorted × dense/sparse inputs, now also asserting the stored `s_indices`) and `test_ddp_to_sa_and_to_product` (values, round-trip semantics including the zero-probability rows, identity on same-form conversion, and solution equality across all representations and methods). `test/test_ddp.jl`: 318 passed; the full package test suite passes. The benchmark suite is unaffected (verified it still builds).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
