### PR TITLE
Add benchmarks for MarkovChain (markov/mc_tools.jl)

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -10,7 +10,9 @@ Each benchmarked module has its own file, included by `benchmarks.jl` as a
 subgroup of `SUITE`. Currently covered:
 
 - [`ddp.jl`](ddp.jl): `DiscreteDP` (`src/markov/ddp.jl`), under
-  `SUITE["ddp"]`.
+  `SUITE["ddp"]`;
+- [`mc_tools.jl`](mc_tools.jl): `MarkovChain` (`src/markov/mc_tools.jl`),
+  under `SUITE["mc_tools"]`.
 
 ## What is benchmarked
 
@@ -54,6 +56,24 @@ convergence behavior.
 
 Note that the suite holds the dense `Q` arrays of the two large cases in
 memory (roughly 0.5 GB in total).
+
+### `mc_tools` ([`mc_tools.jl`](mc_tools.jl))
+
+The suite is organized by function, over random models (dense stochastic
+matrices with normalized random rows; sparse stochastic matrices with `k`
+nonzeros per row, containing a Hamiltonian cycle so that the chain is
+irreducible), each generated with its own fixed-seed RNG:
+
+| Key | Description |
+|:----|:------------|
+| `gth_solve/n{50,200,1000}` | GTH solver on a dense stochastic matrix |
+| `constructor/dense_n100`, `constructor/sparse_n1000_k4` | `MarkovChain` construction (input verification) |
+| `stationary_distributions/dense_n200`, `stationary_distributions/sparse_n300_k4` | Recurrent class detection + GTH solve |
+| `simulate/dense_n100_ts10000` | Long path: per-step sampling dominates |
+| `simulate/dense_n1000_ts100` | Short path, many states: per-call setup (matrix conversion, CDF construction) dominates |
+| `simulate/sparse_n1000_k4_ts10000` | Sparse transition matrix (currently converted to dense internally) |
+| `simulate!/dense_n100_10000x10` | 10 paths into a preallocated matrix |
+| `simulate_indices/dense_n100_ts10000` | Long path, index-valued output |
 
 ## Running the suite standalone
 

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -17,6 +17,7 @@ using BenchmarkTools
 const SUITE = BenchmarkGroup()
 
 SUITE["ddp"] = include("ddp.jl")
+SUITE["mc_tools"] = include("mc_tools.jl")
 
 #= Standalone execution =#
 

--- a/benchmark/mc_tools.jl
+++ b/benchmark/mc_tools.jl
@@ -94,27 +94,34 @@ let grp = suite["stationary_distributions"] = BenchmarkGroup()
         $mc_sparse_small)
 end
 
+# The simulation routines draw from the global RNG, so it is re-seeded in
+# `setup` (outside the timed region) to make the sampled paths reproducible
 let grp = suite["simulate"] = BenchmarkGroup()
     # long path: per-step sampling dominates
     grp["dense_n100_ts10000"] =
-        @benchmarkable simulate($mc_dense_small, 10_000; init=1)
+        @benchmarkable simulate($mc_dense_small, 10_000; init=1) setup=(
+            Random.seed!(1234))
     # short path, many states: per-call setup dominates
     grp["dense_n1000_ts100"] =
-        @benchmarkable simulate($mc_dense_large, 100; init=1)
+        @benchmarkable simulate($mc_dense_large, 100; init=1) setup=(
+            Random.seed!(1234))
     # sparse transition matrix (currently converted to dense internally)
     grp["sparse_n1000_k4_ts10000"] =
-        @benchmarkable simulate($mc_sparse, 10_000; init=1)
+        @benchmarkable simulate($mc_sparse, 10_000; init=1) setup=(
+            Random.seed!(1234))
 end
 
 let grp = suite["simulate!"] = BenchmarkGroup()
     X = Matrix{Int}(undef, 10_000, 10)
     grp["dense_n100_10000x10"] =
-        @benchmarkable simulate!($X, $mc_dense_small; init=1)
+        @benchmarkable simulate!($X, $mc_dense_small; init=1) setup=(
+            Random.seed!(1234))
 end
 
 let grp = suite["simulate_indices"] = BenchmarkGroup()
     grp["dense_n100_ts10000"] =
-        @benchmarkable simulate_indices($mc_dense_small, 10_000; init=1)
+        @benchmarkable simulate_indices($mc_dense_small, 10_000; init=1) setup=(
+            Random.seed!(1234))
 end
 
 suite

--- a/benchmark/mc_tools.jl
+++ b/benchmark/mc_tools.jl
@@ -1,0 +1,120 @@
+#=
+Benchmarks for markov/mc_tools.jl (MarkovChain)
+
+Covers the GTH linear solver (`gth_solve`), stationary distribution
+computation, and simulation (`simulate`, `simulate!`, `simulate_indices`),
+for both dense and sparse transition matrices.
+
+The simulation benchmarks include a long-path case (per-step sampling cost
+dominates) and a short-path case with many states (per-call setup cost —
+transition matrix conversion and CDF construction — dominates), so that
+changes to either component are visible separately.
+=#
+using QuantEcon
+using BenchmarkTools
+using Random
+using SparseArrays
+
+#= Model generators =#
+
+# Random dense stochastic matrix. Rows are normalized twice so that the
+# recomputed row sums equal 1 within a few ulps, as required by the strict
+# tolerance of the MarkovChain constructor.
+function random_stochastic_matrix(rng, n)
+    P = rand(rng, n, n)
+    P ./= sum(P, dims=2)
+    P ./= sum(P, dims=2)
+    return P
+end
+
+# Random sparse stochastic matrix with k nonzeros per row. Each row i
+# contains the entry (i, i%n+1), so that the matrix has a Hamiltonian cycle
+# and is therefore irreducible.
+function random_sparse_stochastic_matrix(rng, n, k)
+    rows = Vector{Int}(undef, n * k)
+    cols = Vector{Int}(undef, n * k)
+    vals = Vector{Float64}(undef, n * k)
+    chosen = Vector{Int}(undef, k)
+    idx = 0
+    for i in 1:n
+        chosen[1] = (i % n) + 1
+        for j in 2:k  # draw k-1 additional distinct destination states
+            c = rand(rng, 1:n)
+            while c in view(chosen, 1:j-1)
+                c = rand(rng, 1:n)
+            end
+            chosen[j] = c
+        end
+        w = rand(rng, k)
+        w ./= sum(w)
+        for j in 1:k
+            idx += 1
+            rows[idx], cols[idx], vals[idx] = i, chosen[j], w[j]
+        end
+    end
+    return sparse(rows, cols, vals, n, n)
+end
+
+#= Suite =#
+
+suite = BenchmarkGroup()
+
+# A fresh generator per case, so that adding or reordering cases does not
+# alter the model data of the other cases
+new_rng() = MersenneTwister(1234)
+
+# gth_solve: raw solver on dense stochastic matrices (the public gth_solve
+# copies its input, so the benchmark includes the O(n^2) copy, which is
+# negligible relative to the O(n^3) elimination)
+let grp = suite["gth_solve"] = BenchmarkGroup()
+    for n in (50, 200, 1000)
+        A = random_stochastic_matrix(new_rng(), n)
+        grp["n$n"] = @benchmarkable gth_solve($A)
+    end
+end
+
+# Model cases shared by the remaining groups
+mc_dense_small = MarkovChain(random_stochastic_matrix(new_rng(), 100))
+mc_dense_large = MarkovChain(random_stochastic_matrix(new_rng(), 1000))
+mc_sparse = MarkovChain(random_sparse_stochastic_matrix(new_rng(), 1000, 4))
+
+let grp = suite["constructor"] = BenchmarkGroup()
+    grp["dense_n100"] = @benchmarkable MarkovChain($(mc_dense_small.p))
+    grp["sparse_n1000_k4"] = @benchmarkable MarkovChain($(mc_sparse.p))
+end
+
+# stationary_distributions: recurrent class detection + GTH solve; the
+# random matrices are irreducible, so there is exactly one class
+let grp = suite["stationary_distributions"] = BenchmarkGroup()
+    mc_sparse_small = MarkovChain(random_sparse_stochastic_matrix(
+        new_rng(), 300, 4))
+    grp["dense_n200"] = @benchmarkable stationary_distributions(
+        $(MarkovChain(random_stochastic_matrix(new_rng(), 200))))
+    grp["sparse_n300_k4"] = @benchmarkable stationary_distributions(
+        $mc_sparse_small)
+end
+
+let grp = suite["simulate"] = BenchmarkGroup()
+    # long path: per-step sampling dominates
+    grp["dense_n100_ts10000"] =
+        @benchmarkable simulate($mc_dense_small, 10_000; init=1)
+    # short path, many states: per-call setup dominates
+    grp["dense_n1000_ts100"] =
+        @benchmarkable simulate($mc_dense_large, 100; init=1)
+    # sparse transition matrix (currently converted to dense internally)
+    grp["sparse_n1000_k4_ts10000"] =
+        @benchmarkable simulate($mc_sparse, 10_000; init=1)
+end
+
+let grp = suite["simulate!"] = BenchmarkGroup()
+    X = Matrix{Int}(undef, 10_000, 10)
+    grp["dense_n100_10000x10"] =
+        @benchmarkable simulate!($X, $mc_dense_small; init=1)
+end
+
+let grp = suite["simulate_indices"] = BenchmarkGroup()
+    grp["dense_n100_ts10000"] =
+        @benchmarkable simulate_indices($mc_dense_small, 10_000; init=1)
+end
+
+suite

--- a/benchmark/mc_tools.jl
+++ b/benchmark/mc_tools.jl
@@ -61,22 +61,22 @@ suite = BenchmarkGroup()
 
 # A fresh generator per case, so that adding or reordering cases does not
 # alter the model data of the other cases
-new_rng() = MersenneTwister(1234)
+new_mc_rng() = MersenneTwister(1234)
 
 # gth_solve: raw solver on dense stochastic matrices (the public gth_solve
 # copies its input, so the benchmark includes the O(n^2) copy, which is
 # negligible relative to the O(n^3) elimination)
 let grp = suite["gth_solve"] = BenchmarkGroup()
     for n in (50, 200, 1000)
-        A = random_stochastic_matrix(new_rng(), n)
+        A = random_stochastic_matrix(new_mc_rng(), n)
         grp["n$n"] = @benchmarkable gth_solve($A)
     end
 end
 
 # Model cases shared by the remaining groups
-mc_dense_small = MarkovChain(random_stochastic_matrix(new_rng(), 100))
-mc_dense_large = MarkovChain(random_stochastic_matrix(new_rng(), 1000))
-mc_sparse = MarkovChain(random_sparse_stochastic_matrix(new_rng(), 1000, 4))
+mc_dense_small = MarkovChain(random_stochastic_matrix(new_mc_rng(), 100))
+mc_dense_large = MarkovChain(random_stochastic_matrix(new_mc_rng(), 1000))
+mc_sparse = MarkovChain(random_sparse_stochastic_matrix(new_mc_rng(), 1000, 4))
 
 let grp = suite["constructor"] = BenchmarkGroup()
     grp["dense_n100"] = @benchmarkable MarkovChain($(mc_dense_small.p))
@@ -87,41 +87,44 @@ end
 # random matrices are irreducible, so there is exactly one class
 let grp = suite["stationary_distributions"] = BenchmarkGroup()
     mc_sparse_small = MarkovChain(random_sparse_stochastic_matrix(
-        new_rng(), 300, 4))
+        new_mc_rng(), 300, 4))
     grp["dense_n200"] = @benchmarkable stationary_distributions(
-        $(MarkovChain(random_stochastic_matrix(new_rng(), 200))))
+        $(MarkovChain(random_stochastic_matrix(new_mc_rng(), 200))))
     grp["sparse_n300_k4"] = @benchmarkable stationary_distributions(
         $mc_sparse_small)
 end
 
 # The simulation routines draw from the global RNG, so it is re-seeded in
-# `setup` (outside the timed region) to make the sampled paths reproducible
+# `setup` (outside the timed region) to make the sampled paths reproducible.
+# `setup` runs once per sample, not per evaluation, so `evals=1` is pinned
+# to keep every evaluation seeded (relevant once these get fast enough for
+# the tuner to pick evals > 1)
 let grp = suite["simulate"] = BenchmarkGroup()
     # long path: per-step sampling dominates
     grp["dense_n100_ts10000"] =
         @benchmarkable simulate($mc_dense_small, 10_000; init=1) setup=(
-            Random.seed!(1234))
+            Random.seed!(1234)) evals=1
     # short path, many states: per-call setup dominates
     grp["dense_n1000_ts100"] =
         @benchmarkable simulate($mc_dense_large, 100; init=1) setup=(
-            Random.seed!(1234))
+            Random.seed!(1234)) evals=1
     # sparse transition matrix (currently converted to dense internally)
     grp["sparse_n1000_k4_ts10000"] =
         @benchmarkable simulate($mc_sparse, 10_000; init=1) setup=(
-            Random.seed!(1234))
+            Random.seed!(1234)) evals=1
 end
 
 let grp = suite["simulate!"] = BenchmarkGroup()
     X = Matrix{Int}(undef, 10_000, 10)
     grp["dense_n100_10000x10"] =
         @benchmarkable simulate!($X, $mc_dense_small; init=1) setup=(
-            Random.seed!(1234))
+            Random.seed!(1234)) evals=1
 end
 
 let grp = suite["simulate_indices"] = BenchmarkGroup()
     grp["dense_n100_ts10000"] =
         @benchmarkable simulate_indices($mc_dense_small, 10_000; init=1) setup=(
-            Random.seed!(1234))
+            Random.seed!(1234)) evals=1
 end
 
 suite


### PR DESCRIPTION
This PR adds `SUITE["mc_tools"]` to the benchmark suite, ahead of planned fix and performance work on `markov/mc_tools.jl`, so that a committed baseline exists for `judge`-style comparisons.

## What is benchmarked

- `gth_solve/n{50,200,1000}`: the GTH solver on dense stochastic matrices.
- `constructor/{dense_n100,sparse_n1000_k4}`: `MarkovChain` construction (input verification).
- `stationary_distributions/{dense_n200,sparse_n300_k4}`: recurrent class detection + GTH solve.
- `simulate/dense_n100_ts10000`: long path, where per-step sampling dominates.
- `simulate/dense_n1000_ts100`: short path with many states, where the per-call setup (transition matrix conversion and CDF construction) dominates.
- `simulate/sparse_n1000_k4_ts10000`: sparse transition matrix (currently converted to dense internally).
- `simulate!/dense_n100_10000x10`: 10 paths into a preallocated matrix.
- `simulate_indices/dense_n100_ts10000`: long path, index-valued output.

The two dense `simulate` cases are deliberately split so that changes to the per-step sampling cost and to the per-call setup cost are visible independently.

## Notes

- Random models are generated with fixed-seed RNGs, one per case, following the conventions of `benchmark/ddp.jl`. The sparse generator includes a Hamiltonian cycle so that the chains are irreducible.
- The dense generator normalizes rows twice because the strict absolute row-sum tolerance (5e-15) in `check_stochastic_matrix` rejects singly-normalized random matrices at n=1000; this workaround can be simplified if the tolerance is relaxed.

## Baseline (minimum times)

| Benchmark | Time | Memory |
|:--|--:|--:|
| `gth_solve/n50` | 14.3 μs | 58.8 KiB |
| `gth_solve/n200` | 839 μs | 841.7 KiB |
| `gth_solve/n1000` | 105.7 ms | 19.9 MiB |
| `constructor/dense_n100` | 1.4 μs | 1.9 KiB |
| `constructor/sparse_n1000_k4` | 2.9 μs | 24.3 KiB |
| `stationary_distributions/dense_n200` | 1.81 ms | 3.9 MiB |
| `stationary_distributions/sparse_n300_k4` | 2.92 ms | 2.0 MiB |
| `simulate/dense_n100_ts10000` | 307 μs | 290.0 KiB |
| `simulate/dense_n1000_ts100` | 928 μs | 15.6 MiB |
| `simulate/sparse_n1000_k4_ts10000` | 1.83 ms | 15.7 MiB |
| `simulate!/dense_n100_10000x10` | 2.97 ms | 193.9 KiB |
| `simulate_indices/dense_n100_ts10000` | 308 μs | 290.0 KiB |

## Comparison with QuantEcon.py

For reference, the same cases were mirrored against QuantEcon.py (current `main` working tree; same machine; minimum times; numba warmed up). "Warm" means the instance caches (`_cdfs`, `_stationary_dists`) are hot, which is Python's steady state; "cold" constructs a fresh `MarkovChain` per call, which matches what the Julia implementation currently does on every `simulate` call.

| Benchmark | Julia | Python (warm) | Python (cold) |
|:--|--:|--:|--:|
| `gth_solve/n50` | 14.3 μs | 14.7 μs | — |
| `gth_solve/n200` | 839 μs | 921 μs | — |
| `gth_solve/n500` | 13.25 ms | 14.41 ms | — |
| `gth_solve/n1000` | 105.7 ms | 113.0 ms | — |
| `gth_solve/n2000` | 856.7 ms | 887.3 ms | — |
| `constructor/dense_n100` | 1.4 μs | 13.6 μs | — |
| `constructor/sparse_n1000_k4` | 2.9 μs | 27.3 μs | — |
| `stationary_distributions/dense_n200` | 1.81 ms | 0.92 ms | — |
| `stationary_distributions/sparse_n300_k4` | 2.92 ms | 3.16 ms | — |
| `simulate/dense_n100_ts10000` | 307 μs | 296 μs | 327 μs |
| `simulate/dense_n1000_ts100` | 928 μs | 10.4 μs | 2.88 ms |
| `simulate/sparse_n1000_k4_ts10000` | 1.83 ms | 191 μs | 748 μs |
| `simulate!/dense_n100_10000x10` | 2.97 ms | 2.91 ms | — |
| `simulate_indices/dense_n100_ts10000` | 308 μs | 296 μs | — |

Takeaways:

- `gth_solve` is at parity across all sizes (Julia 3–9% ahead), and both implementations scale cleanly as n^3.
- On the setup-dominated `simulate` case, warm Python is ~89x faster than Julia because Python caches the CDFs on the instance while Julia rebuilds them on every call; Julia beats cold Python, so the per-call setup itself is not the problem.
- Sparse `simulate` is ~10x faster in warm Python (dedicated CSR kernel + caching), while Julia densifies the transition matrix.
- `stationary_distributions` on the dense case is ~2x slower in Julia: its total is roughly `gth_solve` plus ~1 ms of `DiGraph` construction from the dense matrix, whereas Python's total is essentially `gth_solve` alone (scipy csgraph recurrent-class detection is nearly free).

These gaps are the targets of the planned performance PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
