### PR TITLE
ENH: Support sparse output in random_stochastic_matrix, random_markov_chain

### DIFF
--- a/benchmark/mc_tools.jl
+++ b/benchmark/mc_tools.jl
@@ -17,10 +17,16 @@ using SparseArrays
 
 #= Model generators =#
 
+# The generators are deliberately local (prefixed to avoid shadowing
+# QuantEcon.random_stochastic_matrix): they provide guarantees the package
+# generators do not (row sums within the constructor tolerance at any size,
+# irreducibility of the sparse chain), and keep the benchmark models
+# independent of changes to markov/random_mc.jl.
+
 # Random dense stochastic matrix. Rows are normalized twice so that the
 # recomputed row sums equal 1 within a few ulps, as required by the strict
 # tolerance of the MarkovChain constructor.
-function random_stochastic_matrix(rng, n)
+function mc_random_stochastic_matrix(rng, n)
     P = rand(rng, n, n)
     P ./= sum(P, dims=2)
     P ./= sum(P, dims=2)
@@ -30,7 +36,7 @@ end
 # Random sparse stochastic matrix with k nonzeros per row. Each row i
 # contains the entry (i, i%n+1), so that the matrix has a Hamiltonian cycle
 # and is therefore irreducible.
-function random_sparse_stochastic_matrix(rng, n, k)
+function mc_random_sparse_stochastic_matrix(rng, n, k)
     rows = Vector{Int}(undef, n * k)
     cols = Vector{Int}(undef, n * k)
     vals = Vector{Float64}(undef, n * k)
@@ -68,15 +74,15 @@ new_mc_rng() = MersenneTwister(1234)
 # negligible relative to the O(n^3) elimination)
 let grp = suite["gth_solve"] = BenchmarkGroup()
     for n in (50, 200, 1000)
-        A = random_stochastic_matrix(new_mc_rng(), n)
+        A = mc_random_stochastic_matrix(new_mc_rng(), n)
         grp["n$n"] = @benchmarkable gth_solve($A)
     end
 end
 
 # Model cases shared by the remaining groups
-mc_dense_small = MarkovChain(random_stochastic_matrix(new_mc_rng(), 100))
-mc_dense_large = MarkovChain(random_stochastic_matrix(new_mc_rng(), 1000))
-mc_sparse = MarkovChain(random_sparse_stochastic_matrix(new_mc_rng(), 1000, 4))
+mc_dense_small = MarkovChain(mc_random_stochastic_matrix(new_mc_rng(), 100))
+mc_dense_large = MarkovChain(mc_random_stochastic_matrix(new_mc_rng(), 1000))
+mc_sparse = MarkovChain(mc_random_sparse_stochastic_matrix(new_mc_rng(), 1000, 4))
 
 let grp = suite["constructor"] = BenchmarkGroup()
     grp["dense_n100"] = @benchmarkable MarkovChain($(mc_dense_small.p))
@@ -86,10 +92,10 @@ end
 # stationary_distributions: recurrent class detection + GTH solve; the
 # random matrices are irreducible, so there is exactly one class
 let grp = suite["stationary_distributions"] = BenchmarkGroup()
-    mc_sparse_small = MarkovChain(random_sparse_stochastic_matrix(
+    mc_sparse_small = MarkovChain(mc_random_sparse_stochastic_matrix(
         new_mc_rng(), 300, 4))
     grp["dense_n200"] = @benchmarkable stationary_distributions(
-        $(MarkovChain(random_stochastic_matrix(new_mc_rng(), 200))))
+        $(MarkovChain(mc_random_stochastic_matrix(new_mc_rng(), 200))))
     grp["sparse_n300_k4"] = @benchmarkable stationary_distributions(
         $mc_sparse_small)
 end

--- a/src/markov/random_mc.jl
+++ b/src/markov/random_mc.jl
@@ -20,7 +20,7 @@ has `k` states with positive transition probability.
 - `n::Integer`: Number of states.
 - `k::Integer=n`: Number of nonzero entries in each row of the matrix. Set
   to `n` if none specified.
-- `sparse::Union{Val{true},Val{false}}(Val(false))`: If `Val(true)`, the
+- `sparse::Union{Val{true},Val{false}}=Val(false)`: If `Val(true)`, the
   transition matrix is stored as a `SparseMatrixCSC`.
 
 # Returns
@@ -77,7 +77,7 @@ for each row.
 - `n::Integer`: Number of states.
 - `k::Integer=n`: Number of nonzero entries in each row of the matrix. Set
   to `n` if none specified.
-- `sparse::Union{Val{true},Val{false}}(Val(false))`: If `Val(true)`, return a
+- `sparse::Union{Val{true},Val{false}}=Val(false)`: If `Val(true)`, return a
   `SparseMatrixCSC` instead of a dense matrix. For a given `rng`, both
   formats sample the same matrix.
 
@@ -118,7 +118,7 @@ end
 
 
 """
-    _random_nonzero_indices([rng], n, m, k)
+    _random_nonzero_indices(rng, n, m, k)
 
 Sample, for each of `m` probability vectors, the indices in `1:n` of its `k`
 nonzero entries, concatenated into one vector of length `k*m`. Trivially

--- a/src/markov/random_mc.jl
+++ b/src/markov/random_mc.jl
@@ -9,7 +9,7 @@ import QuantEcon: MarkovChain, DiscreteDP
 
 # random_markov_chain
 """
-    random_markov_chain([rng], n[, k])
+    random_markov_chain([rng], n[, k]; sparse=Val(false))
 
 Return a randomly sampled MarkovChain instance with `n` states, where each state
 has `k` states with positive transition probability.
@@ -18,8 +18,10 @@ has `k` states with positive transition probability.
 
 - `rng::AbstractRNG=GLOBAL_RNG`: Random number generator.
 - `n::Integer`: Number of states.
-- `k::Integer=n`: Number of nonzero entries in each column of the matrix. Set
+- `k::Integer=n`: Number of nonzero entries in each row of the matrix. Set
   to `n` if none specified.
+- `sparse::Union{Val{true},Val{false}}(Val(false))`: If `Val(true)`, the
+  transition matrix is stored as a `SparseMatrixCSC`.
 
 # Returns
 
@@ -49,50 +51,95 @@ julia> mc.p
  0.753163  0.246837  0.0
 ```
 """
-function random_markov_chain(rng::AbstractRNG, n::Integer, k::Integer=n)
-    p = random_stochastic_matrix(rng, n, k)
+function random_markov_chain(rng::AbstractRNG, n::Integer, k::Integer=n;
+                             sparse::Union{Val{true},Val{false}}=Val(false))
+    p = random_stochastic_matrix(rng, n, k, sparse=sparse)
     mc = MarkovChain(p)
     return mc
 end
 
-random_markov_chain(n::Integer, k::Integer=n) =
-    random_markov_chain(Random.GLOBAL_RNG, n, k)
+random_markov_chain(n::Integer, k::Integer=n;
+                    sparse::Union{Val{true},Val{false}}=Val(false)) =
+    random_markov_chain(Random.GLOBAL_RNG, n, k, sparse=sparse)
 
 
 # random_stochastic_matrix
 
 """
-    random_stochastic_matrix([rng], n[, k])
+    random_stochastic_matrix([rng], n[, k]; sparse=Val(false))
 
-Return a randomly sampled `n x n` stochastic matrix with `k` nonzero entries for
-each row.
+Return a randomly sampled `n x n` stochastic matrix with `k` nonzero entries
+for each row.
 
 # Arguments
 
 - `rng::AbstractRNG=GLOBAL_RNG`: Random number generator.
 - `n::Integer`: Number of states.
-- `k::Integer=n`: Number of nonzero entries in each column of the matrix. Set
+- `k::Integer=n`: Number of nonzero entries in each row of the matrix. Set
   to `n` if none specified.
+- `sparse::Union{Val{true},Val{false}}(Val(false))`: If `Val(true)`, return a
+  `SparseMatrixCSC` instead of a dense matrix. For a given `rng`, both
+  formats sample the same matrix.
 
 # Returns
 
-- `p::Array`: Stochastic matrix.
+- `p::AbstractMatrix`: Stochastic matrix.
 """
-function random_stochastic_matrix(rng::AbstractRNG, n::Integer, k::Integer=n)
+function random_stochastic_matrix(rng::AbstractRNG, n::Integer, k::Integer=n;
+                                  sparse::Union{Val{true},Val{false}}=Val(false))
+    _random_stochastic_matrix_check(n, k)
+
+    if sparse isa Val{false}
+        p = _random_stochastic_matrix(rng, n, n, k=k)
+        return transpose(p)
+    else
+        probvecs = random_probvec(rng, k, n)  # probvecs[:, j] is row j of p
+        col_indices = _random_nonzero_indices(rng, n, n, k)
+        row_indices = repeat(1:n, inner=k)
+        return SparseArrays.sparse(row_indices, col_indices, vec(probvecs),
+                                   n, n)
+    end
+end
+
+random_stochastic_matrix(n::Integer, k::Integer=n;
+                         sparse::Union{Val{true},Val{false}}=Val(false)) =
+    random_stochastic_matrix(Random.GLOBAL_RNG, n, k, sparse=sparse)
+
+
+function _random_stochastic_matrix_check(n::Integer, k::Integer)
     if !(n > 0)
         throw(ArgumentError("n must be a positive integer"))
     end
     if !(k > 0 && k <= n)
         throw(ArgumentError("k must be an integer with 0 < k <= n"))
     end
-
-    p = _random_stochastic_matrix(rng, n, n, k=k)
-
-    return transpose(p)
+    return nothing
 end
 
-random_stochastic_matrix(n::Integer, k::Integer=n) =
-    random_stochastic_matrix(Random.GLOBAL_RNG, n, k)
+
+"""
+    _random_nonzero_indices([rng], n, m, k)
+
+Sample, for each of `m` probability vectors, the indices in `1:n` of its `k`
+nonzero entries, concatenated into one vector of length `k*m`. Trivially
+`1:n` for each vector if `k == n`, consuming no random numbers, so that for
+a given `rng` all `random_stochastic_matrix` output types sample the same
+matrix.
+"""
+function _random_nonzero_indices(rng::AbstractRNG, n::Integer, m::Integer,
+                                 k::Integer)
+    indices = Vector{Int}(undef, k*m)
+    if k == n
+        for j in 1:m
+            indices[(j-1)*k+1:j*k] = 1:n
+        end
+    else
+        for j in 1:m
+            indices[(j-1)*k+1:j*k] = sample(rng, 1:n, k, replace=false)
+        end
+    end
+    return indices
+end
 
 
 """
@@ -122,10 +169,7 @@ function _random_stochastic_matrix(rng::AbstractRNG, n::Integer, m::Integer;
 
     # if k < n
     # Randomly sample row indices for each column for nonzero values
-    row_indices = Vector{Int}(undef, k*m)
-    for j in 1:m
-        row_indices[(j-1)*k+1:j*k] = sample(rng, 1:n, k, replace=false)
-    end
+    row_indices = _random_nonzero_indices(rng, n, m, k)
 
     p = zeros(n, m)
     for j in 1:m

--- a/test/test_random_mc.jl
+++ b/test/test_random_mc.jl
@@ -37,14 +37,16 @@ using Random
         n, k = 5, 3
         seed = 1234
         for k_ in (n, k)
-            P_dense =
-                @inferred random_stochastic_matrix(MersenneTwister(seed), n, k_)
+            rng_dense, rng_sparse = MersenneTwister(seed), MersenneTwister(seed)
+            P_dense = @inferred random_stochastic_matrix(rng_dense, n, k_)
             P_sparse = @inferred random_stochastic_matrix(
-                MersenneTwister(seed), n, k_, sparse=Val(true))
+                rng_sparse, n, k_, sparse=Val(true))
             @test P_sparse isa SparseMatrixCSC{Float64,Int}
             @test nnz(P_sparse) == n * k_
             # the same seed samples the same matrix in both formats
             @test Matrix(P_sparse) == P_dense
+            # and leaves the rng stream in the same state
+            @test rand(rng_sparse) == rand(rng_dense)
         end
 
         mc = @inferred random_markov_chain(MersenneTwister(seed), n, k,
@@ -60,10 +62,12 @@ using Random
 
     @testset "Test random_stochastic_matrix with k=1" begin
         n, k = 3, 1
-        P = random_stochastic_matrix(n, k)
-        @test all((P .== 0) .| (P .== 1))
-        @test all(x->isequal(sum(x), 1),
-                  [P[i, :] for i in 1:size(P)[1]]) == true
+        for P in (random_stochastic_matrix(n, k),
+                  random_stochastic_matrix(n, k, sparse=Val(true)))
+            @test all((P .== 0) .| (P .== 1))
+            @test all(x->isequal(sum(x), 1),
+                      [P[i, :] for i in 1:size(P)[1]]) == true
+        end
     end
 
     @testset "Test errors properly thrown" begin

--- a/test/test_random_mc.jl
+++ b/test/test_random_mc.jl
@@ -33,6 +33,31 @@ using Random
         @test Ps[2] == Ps[1]
     end
 
+    @testset "Test random_stochastic_matrix with sparse=Val(true)" begin
+        n, k = 5, 3
+        seed = 1234
+        for k_ in (n, k)
+            P_dense =
+                @inferred random_stochastic_matrix(MersenneTwister(seed), n, k_)
+            P_sparse = @inferred random_stochastic_matrix(
+                MersenneTwister(seed), n, k_, sparse=Val(true))
+            @test P_sparse isa SparseMatrixCSC{Float64,Int}
+            @test nnz(P_sparse) == n * k_
+            # the same seed samples the same matrix in both formats
+            @test Matrix(P_sparse) == P_dense
+        end
+
+        mc = @inferred random_markov_chain(MersenneTwister(seed), n, k,
+                                           sparse=Val(true))
+        @test mc.p isa SparseMatrixCSC
+        @test size(mc.p) == (n, n)
+        # defaults for k and rng
+        @test random_markov_chain(n, sparse=Val(true)).p isa SparseMatrixCSC
+        @test random_markov_chain(n, k, sparse=Val(true)).p isa SparseMatrixCSC
+
+        @test_throws ArgumentError random_markov_chain(2, 3, sparse=Val(true))
+    end
+
     @testset "Test random_stochastic_matrix with k=1" begin
         n, k = 3, 1
         P = random_stochastic_matrix(n, k)


### PR DESCRIPTION
This PR adds a keyword argument `sparse::Union{Val{true},Val{false}}=Val(false)` to `random_markov_chain` and `random_stochastic_matrix` (#102). With `sparse=Val(true)`, the matrix is built directly as a `SparseMatrixCSC` from the sampled `(row, column, value)` triplets, without materializing it densely. The `Val`-typed flag keeps the methods type stable — tested with `@inferred` — which a plain `Bool` keyword could not, while avoiding a matrix-type argument that the user would have to spell out.

The existing behavior is unchanged, and the random number stream is preserved: for a given `rng`, the dense and sparse formats sample the identical matrix, since the nonzero-position sampling is shared in `_random_nonzero_indices` and consumes no random numbers when `k == n`. This is tested by comparing the two formats at a fixed seed.

A second commit renames the private generators in `benchmark/mc_tools.jl` (added in #391) to `mc_`-prefixed names: they shadowed the `random_stochastic_matrix` export, and they intentionally remain local — they guarantee row sums within the constructor tolerance and irreducibility of the sparse chain, and keep the benchmark models independent of `markov/random_mc.jl` changes.

Closes #102.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)