### PR TITLE
ENH: Add state_values/action_values to DiscreteDP

### DIFF
--- a/examples/ifp_transient_shocks.jl
+++ b/examples/ifp_transient_shocks.jl
@@ -1,0 +1,128 @@
+#=
+Income fluctuation problem with transient and persistent income shocks,
+implementing the model in
+
+    https://python.quantecon.org/ifp_egm_transient_shocks.html
+
+as a DiscreteDP: state (a, z), action = savings, with the transient
+shock integrated into the transition probabilities by Gauss-Hermite
+quadrature and next-period assets assigned to the two bracketing grid
+points (Young's method).
+=#
+
+using QuantEcon, SparseArrays, Plots
+
+function Household(; gamma=1.5, bet=0.96, r=0.01, a_y=0.2, b_y=0.5,
+                   Pi=[0.6 0.4; 0.05 0.95], z_grid=[-10.0, log(2.0)],
+                   n_nodes=7, a_min=1e-10, a_max=20.0, a_size=200)
+    eta, w_eta = qnwnorm(n_nodes, 0.0, 1.0)
+    a_vals = range(a_min, a_max, length=a_size)   # asset states
+    s_grid = range(0.0, a_max, length=a_size)     # savings actions
+    return (; gamma, bet, r, a_y, b_y, Pi, z_grid, a_vals, s_grid, eta, w_eta)
+end
+
+function tabulate(hh)
+    u(c) = c^(1 - hh.gamma) / (1 - hh.gamma)
+    R_gross = 1 + hh.r
+    a_vals, s_grid = hh.a_vals, hh.s_grid
+    state_values = vec([(a, z) for a in a_vals, z in hh.z_grid])
+
+    im = IndexMap(state_values)   # (a_next, z_next) -> next-state index
+    zi = IndexMap(hh.z_grid)      # z -> row of Pi
+
+    R = fill(-Inf, length(state_values), length(s_grid))
+    Q = zeros(length(state_values), length(s_grid), length(state_values))
+    for (s_i, (a, z)) in enumerate(state_values), (k, sav) in enumerate(s_grid)
+        c = a - sav                               # action = savings
+        c > 0 || continue                         # infeasible: R stays -Inf
+        R[s_i, k] = u(c)
+        for (zp_i, zp) in enumerate(hh.z_grid), l in eachindex(hh.eta)
+            ap = clamp(R_gross * sav + exp(hh.a_y * hh.eta[l] + hh.b_y * zp),
+                       first(a_vals), last(a_vals))
+            w = hh.Pi[zi[z], zp_i] * hh.w_eta[l]
+            i = searchsortedlast(a_vals, ap)      # lottery onto the grid
+            if i == length(a_vals)
+                Q[s_i, k, im[(a_vals[i], zp)]] += w
+            else
+                lam = (ap - a_vals[i]) / (a_vals[i+1] - a_vals[i])
+                Q[s_i, k, im[(a_vals[i], zp)]]   += w * (1 - lam)
+                Q[s_i, k, im[(a_vals[i+1], zp)]] += w * lam
+            end
+        end
+    end
+    return DiscreteDP(R, Q, hh.bet; state_values, action_values=s_grid)
+end
+
+hh  = Household()
+res = solve(tabulate(hh), PFI)
+pf  = DDPPolicyFunction(res)                      # (a, z) -> optimal savings
+
+# expected next-period income given current z, by quadrature
+zi = IndexMap(hh.z_grid)
+y_bar(z) = sum(hh.Pi[zi[z], zp_i] *
+               sum(hh.w_eta .* exp.(hh.a_y .* hh.eta .+ hh.b_y * zp))
+               for (zp_i, zp) in enumerate(hh.z_grid))
+
+# current assets vs (expected) next-period assets
+plt = plot(xlabel="current assets", ylabel="next period assets",
+           legend=:topleft)
+for z in hh.z_grid
+    plot!(plt, hh.a_vals, [(1 + hh.r) * pf((a, z)) + y_bar(z) for a in hh.a_vals],
+          label="z = " * string(round(z, digits=2)))
+end
+plot!(plt, hh.a_vals, hh.a_vals, linestyle=:dash, color=:black,
+      label="45 degrees")
+
+# stationary wealth distribution
+stat = stationary_distributions(res.mc)[1]
+a_of_state = first.(res.mc.state_values)
+keep = stat .> 1e-9
+histogram(a_of_state[keep], weights=stat[keep], bins=60, normalize=:pdf,
+          xlabel="assets", ylabel="density")
+
+# state-action pair formulation with sparse Q: dense Q is O(n^2 m), so
+# grid refinement (the stationary distribution converges slowly in the
+# grid step) calls for this form
+function tabulate_sparse(hh)
+    u(c) = c^(1 - hh.gamma) / (1 - hh.gamma)
+    R_gross = 1 + hh.r
+    a_vals, s_grid = hh.a_vals, hh.s_grid
+    state_values = vec([(a, z) for a in a_vals, z in hh.z_grid])
+
+    im = IndexMap(state_values)
+    zi = IndexMap(hh.z_grid)
+
+    s_indices = Int[]; a_indices = Int[]; R_sa = Float64[]
+    QI = Int[]; QJ = Int[]; QV = Float64[]
+    L = 0
+    for (s_i, (a, z)) in enumerate(state_values), (k, sav) in enumerate(s_grid)
+        c = a - sav
+        c > 0 || continue                         # infeasible pair: omitted
+        L += 1
+        push!(s_indices, s_i); push!(a_indices, k); push!(R_sa, u(c))
+        for (zp_i, zp) in enumerate(hh.z_grid), l in eachindex(hh.eta)
+            ap = clamp(R_gross * sav + exp(hh.a_y * hh.eta[l] + hh.b_y * zp),
+                       first(a_vals), last(a_vals))
+            w = hh.Pi[zi[z], zp_i] * hh.w_eta[l]
+            i = searchsortedlast(a_vals, ap)
+            if i == length(a_vals)
+                push!(QI, L); push!(QJ, im[(a_vals[i], zp)]); push!(QV, w)
+            else
+                lam = (ap - a_vals[i]) / (a_vals[i+1] - a_vals[i])
+                push!(QI, L); push!(QJ, im[(a_vals[i], zp)]);   push!(QV, w * (1 - lam))
+                push!(QI, L); push!(QJ, im[(a_vals[i+1], zp)]); push!(QV, w * lam)
+            end
+        end
+    end
+    Q = sparse(QI, QJ, QV, L, length(state_values))   # duplicates are summed
+    return DiscreteDP(R_sa, Q, hh.bet, s_indices, a_indices;
+                      state_values, action_values=s_grid)
+end
+
+hh_fine  = Household(a_size=800)
+res_fine = solve(tabulate_sparse(hh_fine), PFI)
+stat_fine = stationary_distributions(res_fine.mc)[1]
+a_fine = first.(res_fine.mc.state_values)
+println("mean assets: a_size=200 (dense): ",
+        round(sum(stat .* a_of_state), digits=3),
+        "; a_size=800 (sparse): ", round(sum(stat_fine .* a_fine), digits=3))

--- a/src/QuantEcon.jl
+++ b/src/QuantEcon.jl
@@ -104,6 +104,7 @@ export
 
 # util
     meshgrid, gridmake, gridmake!, ckron, is_stable, num_compositions,
+    IndexMap,
     SimplexGrid, simplex_grid, simplex_index, next_k_array!, k_array_rank,
 
 # robustlq
@@ -132,6 +133,7 @@ export
     evaluate_policy, bellman_operator, compute_greedy,
     bellman_operator!, num_states, backward_induction,
     num_sa_pairs, to_sa_pair_form, to_product_form,
+    sigma_values, state_to_index, DDPPolicyFunction, DDPValueFunction,
 
 # zeros / optimization
     bisect, brenth, brent, ridder, expand_bracket, divide_bracket,

--- a/src/markov/ddp.jl
+++ b/src/markov/ddp.jl
@@ -43,18 +43,34 @@ DiscreteDP type for specifying parameters for discrete dynamic programming model
   formulation.
 - `a_indices::Vector{Tind}`: Action indices. Empty unless using SA formulation.
 - `a_indptr::Vector{Tind}`: Action index pointers. Empty unless using SA formulation.
+- `state_values::TSV`: Values associated with the states, of length `n`.
+  Pure decoration for decoding results; the solution methods never read
+  it. Held by reference.
+- `action_values::TAV`: Values associated with the actions. Its length
+  defines the number of actions `m`; for the state-action pair
+  formulation, actions not referenced by `a_indices` are allowed
+  (feasible nowhere). Held by reference. Values are labels, not
+  identifiers: repeated labels are legal and mean shared display names
+  (actions) or observable-level annotation (states); uniqueness is
+  demanded only by operations that invert (see `IndexMap`,
+  `state_to_index`, `DDPPolicyFunction`).
 
 """
-mutable struct DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind,TQ<:AbstractArray{T,NQ}}
+mutable struct DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind,TQ<:AbstractArray{T,NQ},
+                          TSV<:AbstractVector,TAV<:AbstractVector}
     R::Array{T,NR}                     # Reward Array
     Q::TQ                     # Transition Probability Array
     beta::Tbeta                        # Discount Factor
     s_indices::Vector{Tind}  # State Indices
     a_indices::Vector{Tind}  # Action Indices
     a_indptr::Vector{Tind}   # Action Index Pointers
+    state_values::TSV        # State Values
+    action_values::TAV       # Action Values
 
     function DiscreteDP{T,NQ,NR,Tbeta,Tind,TQ}(
-            R::Array, Q::TQ, beta::Real
+            R::Array, Q::TQ, beta::Real;
+            state_values::AbstractVector=1:size(R, 1),
+            action_values::AbstractVector=1:size(R, 2)
         ) where {T,NQ,NR,Tbeta,Tind,TQ}
         # verify input integrity 1
         if NQ != 3
@@ -76,6 +92,18 @@ mutable struct DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind,TQ<:AbstractArray{T,NQ}
             throw(ArgumentError("shapes of R and Q must be (n,m) and (n,m,n)"))
         end
 
+        # verify state/action values
+        if length(state_values) != num_states
+            msg = "length of state_values must be equal to the number " *
+                  "of states"
+            throw(ArgumentError(msg))
+        end
+        if length(action_values) != num_actions
+            msg = "length of action_values must be equal to the number " *
+                  "of actions"
+            throw(ArgumentError(msg))
+        end
+
         # check feasibility
         R_max = s_wise_max(R)
         if any(R_max .== -Inf)
@@ -90,8 +118,9 @@ mutable struct DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind,TQ<:AbstractArray{T,NQ}
         _a_indices = Vector{Int}()
         a_indptr = Vector{Int}()
 
-        new{T,NQ,NR,Tbeta,Tind,typeof(Q)}(R, Q, beta, _s_indices, _a_indices,
-                                          a_indptr)
+        new{T,NQ,NR,Tbeta,Tind,typeof(Q),typeof(state_values),
+            typeof(action_values)}(R, Q, beta, _s_indices, _a_indices,
+                                   a_indptr, state_values, action_values)
     end
 
     # Note: We left R, Q as type Array to produce more helpful error message with regards to shape.
@@ -99,7 +128,9 @@ mutable struct DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind,TQ<:AbstractArray{T,NQ}
 
     function DiscreteDP{T,NQ,NR,Tbeta,Tind,TQ}(
             R::AbstractArray, Q::TQ, beta::Real, s_indices::Vector,
-            a_indices::Vector
+            a_indices::Vector;
+            state_values::AbstractVector=1:size(Q, 2),
+            action_values::AbstractVector=1:maximum(a_indices)
         ) where {T,NQ,NR,Tbeta,Tind,TQ}
         # verify input integrity 1
         if NQ != 2
@@ -133,6 +164,17 @@ mutable struct DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind,TQ<:AbstractArray{T,NQ}
         end
         if any(a -> a < 1, a_indices)
             throw(ArgumentError("a_indices must be positive"))
+        end
+
+        # verify state/action values
+        if length(state_values) != num_states
+            msg = "length of state_values must be equal to the number " *
+                  "of states"
+            throw(ArgumentError(msg))
+        end
+        if maximum(a_indices) > length(action_values)
+            msg = "a_indices must not exceed the length of action_values"
+            throw(ArgumentError(msg))
         end
 
         if _has_sorted_sa_indices(s_indices, a_indices)
@@ -186,13 +228,15 @@ mutable struct DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind,TQ<:AbstractArray{T,NQ}
             Q = transpose(sparse(transpose(Q)))
         end
 
-        new{T,NQ,NR,Tbeta,Tind,typeof(Q)}(R, Q, beta, _s_indices, _a_indices,
-                                          a_indptr)
+        new{T,NQ,NR,Tbeta,Tind,typeof(Q),typeof(state_values),
+            typeof(action_values)}(R, Q, beta, _s_indices, _a_indices,
+                                   a_indptr, state_values, action_values)
     end
 end
 
 """
-    DiscreteDP(R, Q, beta)
+    DiscreteDP(R, Q, beta; state_values=1:size(R, 1),
+               action_values=1:size(R, 2))
 
 DiscreteDP constructor for specifying parameters for discrete dynamic programming
 model using dense matrix formulation.
@@ -202,6 +246,10 @@ model using dense matrix formulation.
 - `R::Array{T,NR}`: Reward array.
 - `Q::AbstractArray{T,NQ}`: Transition probability array.
 - `beta::Real`: Discount factor.
+- `;state_values::AbstractVector(1:size(R, 1))`: Values associated with
+  the states, of length `n`.
+- `;action_values::AbstractVector(1:size(R, 2))`: Values associated with
+  the actions, of length `m`.
 
 # Returns
 
@@ -209,12 +257,15 @@ model using dense matrix formulation.
 
 """
 function DiscreteDP(
-    R::Array{T,NR}, Q::AbstractArray{T,NQ}, beta::Tbeta) where {T,NQ,NR,Tbeta}
-    DiscreteDP{T,NQ,NR,Tbeta,Int,typeof(Q)}(R, Q, beta)
+    R::Array{T,NR}, Q::AbstractArray{T,NQ}, beta::Tbeta;
+    kwargs...) where {T,NQ,NR,Tbeta}
+    DiscreteDP{T,NQ,NR,Tbeta,Int,typeof(Q)}(R, Q, beta; kwargs...)
 end
 
 """
-    DiscreteDP(R, Q, beta, s_indices, a_indices)
+    DiscreteDP(R, Q, beta, s_indices, a_indices;
+               state_values=1:size(Q, 2),
+               action_values=1:maximum(a_indices))
 
 DiscreteDP constructor for specifying parameters for discrete dynamic programming
 model using state-action pair formulation.
@@ -226,6 +277,11 @@ model using state-action pair formulation.
 - `beta::Real`: Discount factor.
 - `s_indices::Vector{Tind}`: State indices.
 - `a_indices::Vector{Tind}`: Action indices.
+- `;state_values::AbstractVector(1:size(Q, 2))`: Values associated with
+  the states, of length `n`.
+- `;action_values::AbstractVector(1:maximum(a_indices))`: Values
+  associated with the actions; its length defines the number of actions,
+  and may exceed `maximum(a_indices)` (actions feasible nowhere).
 
 # Returns
 
@@ -235,8 +291,10 @@ model using state-action pair formulation.
 function DiscreteDP(R::AbstractArray{T,NR},
                     Q::AbstractArray{T,NQ},
                     beta::Tbeta, s_indices::Vector{Tind},
-                    a_indices::Vector{Tind}) where {T,NQ,NR,Tbeta,Tind}
-    DiscreteDP{T,NQ,NR,Tbeta,Tind,typeof(Q)}(R, Q, beta, s_indices, a_indices)
+                    a_indices::Vector{Tind};
+                    kwargs...) where {T,NQ,NR,Tbeta,Tind}
+    DiscreteDP{T,NQ,NR,Tbeta,Tind,typeof(Q)}(R, Q, beta, s_indices, a_indices;
+                                             kwargs...)
 end
 
 #--------------#
@@ -316,7 +374,9 @@ function to_sa_pair_form(ddp::DDP{T}; sparse::Bool=true) where T
         end
     end
     Q_out = sparse ? SparseArrays.sparse(Q) : Q
-    return DiscreteDP(R, Q_out, ddp.beta, s_indices, a_indices)
+    return DiscreteDP(R, Q_out, ddp.beta, s_indices, a_indices;
+                      state_values=ddp.state_values,
+                      action_values=ddp.action_values)
 end
 
 to_sa_pair_form(ddp::DDPsa; sparse::Bool=true) = ddp
@@ -326,7 +386,8 @@ to_sa_pair_form(ddp::DDPsa; sparse::Bool=true) = ddp
 
 Convert `ddp` to the equivalent `DiscreteDP` in product form, with a
 reward array of shape `(n, m)` and a transition probability array of
-shape `(n, m, n)`, where `m` is the largest action index. Infeasible
+shape `(n, m, n)`, where `m = length(ddp.action_values)` (with the
+default `action_values`, the largest action index). Infeasible
 pairs are assigned a reward of `-Inf` and a zero vector of transition
 probabilities; when such pairs exist, the reward element type must be
 able to represent `-Inf` (a floating point type, or a `Rational`, for
@@ -344,7 +405,7 @@ returned unmodified.
 """
 function to_product_form(ddp::DDPsa{T}) where T
     n = num_states(ddp)
-    m = maximum(ddp.a_indices)
+    m = length(ddp.action_values)
     L = num_sa_pairs(ddp)
     R = Matrix{T}(undef, n, m)
     if L < n * m
@@ -366,7 +427,8 @@ function to_product_form(ddp::DDPsa{T}) where T
     end
     Q = zeros(T, n, m, n)
     _fill_product_Q!(Q, ddp.s_indices, ddp.a_indices, ddp.Q)
-    return DiscreteDP(R, Q, ddp.beta)
+    return DiscreteDP(R, Q, ddp.beta; state_values=ddp.state_values,
+                      action_values=ddp.action_values)
 end
 
 to_product_form(ddp::DDP) = ddp
@@ -791,7 +853,9 @@ end
 """
     MarkovChain(ddp, sigma)
 
-Returns the controlled Markov chain for a given policy `sigma`.
+Returns the controlled Markov chain for a given policy `sigma`. The
+chain carries `ddp.state_values` (by reference), so that simulated paths
+decode themselves.
 
 # Arguments
 
@@ -804,7 +868,179 @@ Returns the controlled Markov chain for a given policy `sigma`.
 
 """
 QuantEcon.MarkovChain(ddp::DiscreteDP, sigma::AbstractVector{<:Integer}) =
-    MarkovChain(RQ_sigma(ddp, sigma)[2])
+    MarkovChain(RQ_sigma(ddp, sigma)[2], ddp.state_values)
+
+"""
+    sigma_values(res)
+
+Return the optimal policy decoded to action values,
+`res.ddp.action_values[res.sigma]`; the entries pair with
+`res.ddp.state_values`.
+
+# Arguments
+
+- `res::DPSolveResult`: Object that contains result variables.
+
+# Returns
+
+- `table::AbstractVector`: Action value of the optimal policy at each
+  state, of length `n`.
+
+"""
+sigma_values(res::DPSolveResult) = res.ddp.action_values[res.sigma]
+
+"""
+    state_to_index(ddp, s)
+
+Return the index of the state with value `s`, compared by `isequal`.
+Intended for casual one-off lookups: each call scans `state_values`; for
+repeated lookups construct an `IndexMap` over `ddp.state_values` once
+and query that instead.
+
+Throws an `ArgumentError` if `s` is not among the state values, or if it
+appears more than once (the lookup is then ambiguous; repeated state
+values are legal as observable-level annotation, but cannot be
+inverted).
+
+# Arguments
+
+- `ddp::DiscreteDP`: Object that contains the model parameters.
+- `s`: State value to look up.
+
+# Returns
+
+- `i::Int`: Index of the state with value `s`.
+
+"""
+function state_to_index(ddp::DiscreteDP, s)
+    svals = ddp.state_values
+    i = findfirst(isequal(s), svals)
+    if i === nothing
+        throw(ArgumentError("state value $(repr(s)) is not in " *
+            "state_values (lookups use isequal; query with values " *
+            "obtained from the object)"))
+    end
+    if findnext(isequal(s), svals, i + 1) !== nothing
+        throw(ArgumentError("state value $(repr(s)) appears more than " *
+            "once in state_values: the index lookup is ambiguous"))
+    end
+    return i
+end
+
+# state_values -> index map for the decode functors, pre-validated with
+# a domain-specific error message (identity ranges are unique by
+# construction and skip the check)
+_state_values_index_map(svals::AbstractUnitRange{<:Integer}) = IndexMap(svals)
+
+function _state_values_index_map(svals::AbstractVector)
+    counts = Dict{eltype(svals),Int}()
+    for v in svals
+        counts[v] = get(counts, v, 0) + 1
+    end
+    if length(counts) != length(svals)
+        dups = join((string(repr(v), " (x", c, ")")
+                     for (v, c) in counts if c > 1), ", ")
+        throw(ArgumentError("state_values contains repeated values: " *
+            dups * "; a total map from state values cannot be " *
+            "constructed. Repeated values remain usable for forward " *
+            "decoding (sigma_values, simulation of res.mc) and for " *
+            "unambiguous queries (state_to_index)."))
+    end
+    return IndexMap(svals)
+end
+
+"""
+    DDPPolicyFunction{TIM,TAV}
+
+Callable policy function of a solved model: `pf(s)` returns the optimal
+action value at the state with value `s`, compared by `isequal` (query
+with values obtained from the model). Holds references to `res.sigma`
+and `res.ddp.action_values`; construct it after the solve is final.
+Read-only after construction.
+
+Construction requires `state_values` to be unique
+(see `state_to_index` for the granularity rule).
+
+# Fields
+
+- `im::TIM`: `IndexMap` over the state values.
+- `sigma::Vector{Int}`: Optimal policy, by state index.
+- `action_values::TAV`: Values associated with the actions.
+
+"""
+struct DDPPolicyFunction{TIM<:IndexMap,TAV<:AbstractVector}
+    im::TIM
+    sigma::Vector{Int}
+    action_values::TAV
+end
+
+"""
+    DDPPolicyFunction(res; im=IndexMap(res.ddp.state_values))
+
+Construct the policy function of a solved model.
+
+# Arguments
+
+- `res::DPSolveResult`: Object that contains result variables.
+- `;im::IndexMap`: Index map over `res.ddp.state_values`; pass a shared
+  one to construct several decode functors with a single map.
+
+# Returns
+
+- `pf::DDPPolicyFunction`: Callable policy function; `pf(s)` returns the
+  optimal action value at the state with value `s`.
+
+"""
+DDPPolicyFunction(res::DPSolveResult;
+                  im::IndexMap=_state_values_index_map(res.ddp.state_values)) =
+    DDPPolicyFunction(im, res.sigma, res.ddp.action_values)
+
+(pf::DDPPolicyFunction)(s) = pf.action_values[pf.sigma[pf.im[s]]]
+
+"""
+    DDPValueFunction{TIM,Tval}
+
+Callable value function of a solved model: `vf(s)` returns the optimal
+value at the state with value `s`, compared by `isequal` (query with
+values obtained from the model). Holds a reference to `res.v`; construct
+it after the solve is final. Read-only after construction.
+
+Construction requires `state_values` to be unique
+(see `state_to_index` for the granularity rule).
+
+# Fields
+
+- `im::TIM`: `IndexMap` over the state values.
+- `v::Vector{Tval}`: Optimal value function, by state index.
+
+"""
+struct DDPValueFunction{TIM<:IndexMap,Tval}
+    im::TIM
+    v::Vector{Tval}
+end
+
+"""
+    DDPValueFunction(res; im=IndexMap(res.ddp.state_values))
+
+Construct the value function of a solved model.
+
+# Arguments
+
+- `res::DPSolveResult`: Object that contains result variables.
+- `;im::IndexMap`: Index map over `res.ddp.state_values`; pass a shared
+  one to construct several decode functors with a single map.
+
+# Returns
+
+- `vf::DDPValueFunction`: Callable value function; `vf(s)` returns the
+  optimal value at the state with value `s`.
+
+"""
+DDPValueFunction(res::DPSolveResult;
+                 im::IndexMap=_state_values_index_map(res.ddp.state_values)) =
+    DDPValueFunction(im, res.v)
+
+(vf::DDPValueFunction)(s) = vf.v[vf.im[s]]
 
 """
     RQ_sigma(ddp, sigma)

--- a/src/markov/ddp.jl
+++ b/src/markov/ddp.jl
@@ -130,7 +130,8 @@ mutable struct DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind,TQ<:AbstractArray{T,NQ}
             R::AbstractArray, Q::TQ, beta::Real, s_indices::Vector,
             a_indices::Vector;
             state_values::AbstractVector=1:size(Q, 2),
-            action_values::AbstractVector=1:maximum(a_indices)
+            action_values::AbstractVector=
+                1:(isempty(a_indices) ? 0 : maximum(a_indices))
         ) where {T,NQ,NR,Tbeta,Tind,TQ}
         # verify input integrity 1
         if NQ != 2
@@ -172,7 +173,7 @@ mutable struct DiscreteDP{T<:Real,NQ,NR,Tbeta<:Real,Tind,TQ<:AbstractArray{T,NQ}
                   "of states"
             throw(ArgumentError(msg))
         end
-        if maximum(a_indices) > length(action_values)
+        if !isempty(a_indices) && maximum(a_indices) > length(action_values)
             msg = "a_indices must not exceed the length of action_values"
             throw(ArgumentError(msg))
         end
@@ -949,6 +950,16 @@ function _state_values_index_map(svals::AbstractVector)
     return IndexMap(svals)
 end
 
+# a caller-supplied index map must index state_values in the same
+# order: a mismatched map would silently permute the decoded solution
+function _check_im_matches(im::IndexMap, svals::AbstractVector)
+    if !(im.vals === svals || isequal(im.vals, svals))
+        throw(ArgumentError("im must index res.ddp.state_values in the " *
+            "same order"))
+    end
+    return nothing
+end
+
 """
     DDPPolicyFunction{TIM,TAV}
 
@@ -983,7 +994,9 @@ Construct the policy function of a solved model.
 
 - `res::DPSolveResult`: Object that contains result variables.
 - `;im::IndexMap`: Index map over `res.ddp.state_values`; pass a shared
-  one to construct several decode functors with a single map.
+  one to construct several decode functors with a single map. Must
+  index `res.ddp.state_values` in the same order (validated at
+  construction).
 
 # Returns
 
@@ -991,9 +1004,12 @@ Construct the policy function of a solved model.
   optimal action value at the state with value `s`.
 
 """
-DDPPolicyFunction(res::DPSolveResult;
-                  im::IndexMap=_state_values_index_map(res.ddp.state_values)) =
-    DDPPolicyFunction(im, res.sigma, res.ddp.action_values)
+function DDPPolicyFunction(res::DPSolveResult;
+                           im::IndexMap=
+                               _state_values_index_map(res.ddp.state_values))
+    _check_im_matches(im, res.ddp.state_values)
+    return DDPPolicyFunction(im, res.sigma, res.ddp.action_values)
+end
 
 (pf::DDPPolicyFunction)(s) = pf.action_values[pf.sigma[pf.im[s]]]
 
@@ -1028,7 +1044,9 @@ Construct the value function of a solved model.
 
 - `res::DPSolveResult`: Object that contains result variables.
 - `;im::IndexMap`: Index map over `res.ddp.state_values`; pass a shared
-  one to construct several decode functors with a single map.
+  one to construct several decode functors with a single map. Must
+  index `res.ddp.state_values` in the same order (validated at
+  construction).
 
 # Returns
 
@@ -1036,9 +1054,12 @@ Construct the value function of a solved model.
   optimal value at the state with value `s`.
 
 """
-DDPValueFunction(res::DPSolveResult;
-                 im::IndexMap=_state_values_index_map(res.ddp.state_values)) =
-    DDPValueFunction(im, res.v)
+function DDPValueFunction(res::DPSolveResult;
+                          im::IndexMap=
+                              _state_values_index_map(res.ddp.state_values))
+    _check_im_matches(im, res.ddp.state_values)
+    return DDPValueFunction(im, res.v)
+end
 
 (vf::DDPValueFunction)(s) = vf.v[vf.im[s]]
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -435,3 +435,103 @@ function k_array_rank(T::Type{<:Integer}, a::Vector{<:Integer})
 end
 
 k_array_rank(a::Vector{<:Integer}) = k_array_rank(Int, a)
+
+"""
+    IndexMap{TV,TD}
+
+Mapping from the values of a vector to their indices: `im[v]` returns
+the index `i` such that `im.vals[i]` equals `v`, and throws an
+informative `ArgumentError` when `v` is not among the values.
+Construction requires the values to be unique. For an
+`AbstractUnitRange` no dictionary is stored and lookups use
+bounds-checked arithmetic.
+
+`IndexMap` is the persistent counterpart of `Base.indexin`, which
+builds an equivalent dictionary internally, answers one batch of
+queries with first-match and `nothing`-on-miss semantics, and discards
+it on every call; `IndexMap` builds the map once, requiring unique
+values, for repeated single-value lookups with informative errors.
+
+Lookups use `isequal`/`hash` semantics: query with values obtained from
+the wrapped vector itself (exact equality); custom mutable value types
+should define `isequal` and `hash`. The vector is held by reference, and
+mutating a stored value corrupts the map.
+
+# Fields
+
+- `vals::TV`: The wrapped vector of values.
+- `dict::TD`: Value-to-index dictionary; `nothing` for an
+  `AbstractUnitRange`.
+
+# Examples
+
+```julia
+julia> im = IndexMap([(0.0, 0.1), (1.0, 0.1), (0.0, 1.0), (1.0, 1.0)]);
+
+julia> im[(0.0, 1.0)]
+3
+```
+"""
+struct IndexMap{TV<:AbstractVector,TD<:Union{Dict,Nothing}}
+    vals::TV
+    dict::TD
+end
+
+"""
+    IndexMap(vals)
+
+Construct an `IndexMap` from `vals`, whose elements must be unique in
+the sense of `isequal` (`ArgumentError` otherwise). The uniqueness check
+also catches the buffer-reuse bug where collecting a lazy generator that
+yields one mutated buffer stores aliases of a single array.
+
+# Arguments
+
+- `vals::AbstractVector`: Vector of unique values.
+
+# Returns
+
+- `im::IndexMap`: Mapping from the values to their indices, satisfying
+  `vals[im[v]] === v`.
+
+"""
+function IndexMap(vals::AbstractVector)
+    dict = Dict{eltype(vals),Int}()
+    sizehint!(dict, length(vals))
+    for (i, v) in pairs(vals)
+        j = get(dict, v, 0)
+        if j != 0
+            throw(ArgumentError("values must be unique: vals[$j] and " *
+                "vals[$i] are equal ($(repr(v))); if vals was collected " *
+                "from a generator, check that it does not yield a reused " *
+                "buffer"))
+        end
+        dict[v] = i
+    end
+    return IndexMap(vals, dict)
+end
+
+IndexMap(vals::AbstractUnitRange{<:Integer}) = IndexMap(vals, nothing)
+
+function Base.getindex(im::IndexMap, v)
+    idx = get(im.dict, v, nothing)
+    if idx === nothing
+        throw(ArgumentError("value $(repr(v)) is not among the values of " *
+            "this IndexMap (lookups use isequal; query with values " *
+            "obtained from the wrapped vector)"))
+    end
+    return idx
+end
+
+function Base.getindex(
+        im::IndexMap{<:AbstractUnitRange{<:Integer},Nothing}, v::Number
+    )
+    r = im.vals
+    if !(isinteger(v) && first(r) <= v <= last(r))
+        throw(ArgumentError("value $(repr(v)) is not among the values of " *
+            "this IndexMap"))
+    end
+    return Int(v) - Int(first(r)) + 1
+end
+
+Base.length(im::IndexMap) = length(im.vals)

--- a/src/util.jl
+++ b/src/util.jl
@@ -531,9 +531,13 @@ function Base.getindex(
     # the arithmetic only proposes a candidate position; the isequal
     # check below is the authority, so that the dict-free specialization
     # has exactly the lookup semantics of the dict-backed map (e.g.
-    # -0.0 must miss against a stored 0, as isequal distinguishes them)
+    # -0.0 must miss against a stored 0, as isequal distinguishes them).
+    # The offset is computed at least at Int precision: the range eltype
+    # itself may be too narrow (Int8 offsets run up to 255), while
+    # BigInt endpoints must stay unconverted
+    P = promote_type(eltype(r), Int)
     i = try
-        Int(v - first(r)) + 1
+        Int(v - convert(P, first(r))) + 1
     catch
         throw(_indexmap_notfound(v))
     end

--- a/src/util.jl
+++ b/src/util.jl
@@ -492,7 +492,7 @@ yields one mutated buffer stores aliases of a single array.
 # Returns
 
 - `im::IndexMap`: Mapping from the values to their indices, satisfying
-  `vals[im[v]] === v`.
+  `isequal(vals[im[v]], v)`.
 
 """
 function IndexMap(vals::AbstractVector)
@@ -513,25 +513,33 @@ end
 
 IndexMap(vals::AbstractUnitRange{<:Integer}) = IndexMap(vals, nothing)
 
+_indexmap_notfound(v) =
+    ArgumentError("value $(repr(v)) is not among the values of this " *
+        "IndexMap (lookups use isequal; query with values obtained " *
+        "from the wrapped vector)")
+
 function Base.getindex(im::IndexMap, v)
     idx = get(im.dict, v, nothing)
-    if idx === nothing
-        throw(ArgumentError("value $(repr(v)) is not among the values of " *
-            "this IndexMap (lookups use isequal; query with values " *
-            "obtained from the wrapped vector)"))
-    end
+    idx === nothing && throw(_indexmap_notfound(v))
     return idx
 end
 
 function Base.getindex(
-        im::IndexMap{<:AbstractUnitRange{<:Integer},Nothing}, v::Number
+        im::IndexMap{<:AbstractUnitRange{<:Integer},Nothing}, v
     )
     r = im.vals
-    if !(isinteger(v) && first(r) <= v <= last(r))
-        throw(ArgumentError("value $(repr(v)) is not among the values of " *
-            "this IndexMap"))
+    # the arithmetic only proposes a candidate position; the isequal
+    # check below is the authority, so that the dict-free specialization
+    # has exactly the lookup semantics of the dict-backed map (e.g.
+    # -0.0 must miss against a stored 0, as isequal distinguishes them)
+    i = try
+        Int(v - first(r)) + 1
+    catch
+        throw(_indexmap_notfound(v))
     end
-    return Int(v) - Int(first(r)) + 1
+    (checkbounds(Bool, r, i) && isequal(r[i], v)) ||
+        throw(_indexmap_notfound(v))
+    return i
 end
 
 Base.length(im::IndexMap) = length(im.vals)

--- a/test/test_ddp.jl
+++ b/test/test_ddp.jl
@@ -733,6 +733,17 @@ Tests for markov/ddp.jl
             _ddp_sa = DiscreteDP(R_sa, Q_sa, beta, s_indices, a_indices;
                                  action_values=[:a, :b, :c])
             @test _ddp_sa.action_values == [:a, :b, :c]
+
+            # empty SA inputs must reach the informative feasibility
+            # error, not an empty-reduction error from the
+            # action_values default
+            _err = try
+                DiscreteDP(Float64[], zeros(0, 2), beta, Int[], Int[])
+            catch _e
+                _e
+            end
+            @test _err isa ArgumentError
+            @test occursin("at least one action", _err.msg)
         end
 
         @testset "conversion threading and phantom actions" begin
@@ -810,6 +821,28 @@ Tests for markov/ddp.jl
             _pf0 = DDPPolicyFunction(_res0)
             @test _pf0.im.dict === nothing
             @test _pf0(1) == _res0.sigma[1]
+        end
+
+        @testset "caller-supplied im is validated" begin
+            _sv = [(0.0, :lo), (1.0, :hi)]
+            _ddp = DiscreteDP(R, Q, beta; state_values=_sv)
+            _res = solve(_ddp, PFI)
+            _pf = DDPPolicyFunction(_res)
+
+            # sharing between functors (the intended use) works
+            _vf = DDPValueFunction(_res; im=_pf.im)
+            @test _vf(_sv[2]) == _res.v[2]
+
+            # an equal-but-distinct map is accepted (cross-result
+            # sharing over an identical state space)
+            _im2 = IndexMap([(0.0, :lo), (1.0, :hi)])
+            @test DDPPolicyFunction(_res; im=_im2)(_sv[1]) == _pf(_sv[1])
+
+            # a mismatched ordering must fail at construction, not
+            # silently permute the decoded solution
+            _bad = IndexMap(reverse(_sv))
+            @test_throws ArgumentError DDPPolicyFunction(_res; im=_bad)
+            @test_throws ArgumentError DDPValueFunction(_res; im=_bad)
         end
 
         @testset "duplicated values: decoration yes, inversion no" begin

--- a/test/test_ddp.jl
+++ b/test/test_ddp.jl
@@ -697,4 +697,145 @@ Tests for markov/ddp.jl
         end
     end
 
+    @testset "state_values and action_values (#120)" begin
+        @testset "identity defaults" begin
+            @test ddp0.state_values == 1:2
+            @test ddp0.action_values == 1:2
+            @test ddp0_sa.state_values == 1:2
+            @test ddp0_sa.action_values == 1:2  # 1:maximum(a_indices)
+        end
+
+        @testset "supplied values are stored by reference" begin
+            _sv = [(0.0, :lo), (1.0, :hi)]
+            _av = [10.0, 20.0]
+            _ddp = DiscreteDP(R, Q, beta; state_values=_sv, action_values=_av)
+            @test _ddp.state_values === _sv
+            @test _ddp.action_values === _av
+            _ddp_sa = DiscreteDP(R_sa, Q_sa, beta, s_indices, a_indices;
+                                 state_values=_sv, action_values=_av)
+            @test _ddp_sa.state_values === _sv
+            @test _ddp_sa.action_values === _av
+        end
+
+        @testset "validation" begin
+            @test_throws ArgumentError DiscreteDP(R, Q, beta;
+                                                  state_values=[:a])
+            @test_throws ArgumentError DiscreteDP(R, Q, beta;
+                                                  action_values=[:a])
+            @test_throws ArgumentError DiscreteDP(R_sa, Q_sa, beta,
+                                                  s_indices, a_indices;
+                                                  state_values=[:a])
+            # SA: length(action_values) < maximum(a_indices)
+            @test_throws ArgumentError DiscreteDP(R_sa, Q_sa, beta,
+                                                  s_indices, a_indices;
+                                                  action_values=[:a])
+            # SA: a proper superset of the referenced actions is legal
+            _ddp_sa = DiscreteDP(R_sa, Q_sa, beta, s_indices, a_indices;
+                                 action_values=[:a, :b, :c])
+            @test _ddp_sa.action_values == [:a, :b, :c]
+        end
+
+        @testset "conversion threading and phantom actions" begin
+            _sv = [(:s, 1), (:s, 2)]
+            _av = [:x, :y, :z]
+            # action :z (index 3) is feasible nowhere
+            _R = [1.0 2.0 -Inf; 3.0 -Inf -Inf]
+            _Q = zeros(2, 3, 2)
+            _Q[1, 1, 1] = 1.0
+            _Q[1, 2, 1] = 1.0
+            _Q[2, 1, 1] = 1.0
+            _ddp = DiscreteDP(_R, _Q, 0.9; state_values=_sv, action_values=_av)
+
+            _ddp_sa = to_sa_pair_form(_ddp)
+            @test _ddp_sa.state_values === _sv
+            @test _ddp_sa.action_values === _av
+            @test maximum(_ddp_sa.a_indices) == 2
+
+            # cardinality restoration: the phantom column comes back
+            _ddp_rt = to_product_form(_ddp_sa)
+            @test _ddp_rt.state_values === _sv
+            @test _ddp_rt.action_values === _av
+            @test _ddp_rt.R == _R
+            @test _ddp_rt.Q == _Q
+
+            # with defaults, dense -> SA attaches 1:m (not 1:max index)
+            _ddp_d = DiscreteDP(_R, _Q, 0.9)
+            _ddp_d_sa = to_sa_pair_form(_ddp_d)
+            @test _ddp_d_sa.action_values == 1:3
+            @test size(to_product_form(_ddp_d_sa).R) == (2, 3)
+        end
+
+        @testset "controlled chain carries state_values" begin
+            _sv = [(0.0, :lo), (1.0, :hi)]
+            _ddp = DiscreteDP(R, Q, beta; state_values=_sv)
+            _res = solve(_ddp, PFI)
+            @test _res.mc.state_values === _sv
+            @test simulate(_res.mc, 3; init=1) isa Vector{eltype(_sv)}
+            _mc = MarkovChain(_ddp, [1, 1])
+            @test _mc.state_values === _sv
+        end
+
+        @testset "decode layer" begin
+            _sv = [(0.0, :lo), (1.0, :hi)]
+            _av = [10.0, 20.0]
+            for _base in ddp0_collection
+                _ddp = _base isa QuantEcon.DDP ?
+                    DiscreteDP(R, Q, beta;
+                               state_values=_sv, action_values=_av) :
+                    DiscreteDP(R_sa, Q_sa, beta, s_indices, a_indices;
+                               state_values=_sv, action_values=_av)
+                _res = solve(_ddp, PFI)
+
+                # sigma_values pairs with state_values
+                @test (@inferred sigma_values(_res)) ==
+                    _av[_res.sigma]
+
+                # state_to_index: exact, ambiguity-free lookups
+                @test state_to_index(_ddp, (1.0, :hi)) == 2
+                @test_throws ArgumentError state_to_index(_ddp, (2.0, :hi))
+
+                # functors: value-keyed queries, fully inferred
+                _pf = @inferred DDPPolicyFunction(_res)
+                _vf = @inferred DDPValueFunction(_res; im=_pf.im)
+                for (_i, _s) in enumerate(_sv)
+                    @test (@inferred _pf(_s)) == _av[_res.sigma[_i]]
+                    @test (@inferred _vf(_s)) == _res.v[_i]
+                end
+                @test_throws ArgumentError _pf((2.0, :hi))
+            end
+
+            # identity defaults degrade seamlessly
+            _res0 = solve(ddp0, PFI)
+            @test sigma_values(_res0) == _res0.sigma
+            _pf0 = DDPPolicyFunction(_res0)
+            @test _pf0.im.dict === nothing
+            @test _pf0(1) == _res0.sigma[1]
+        end
+
+        @testset "duplicated values: decoration yes, inversion no" begin
+            # repeated action labels are legal (shared display names)
+            _ddp_a = DiscreteDP(R, Q, beta; action_values=[:stay, :stay])
+            _res_a = solve(_ddp_a, PFI)
+            @test sigma_values(_res_a) == [:stay, :stay]
+
+            # repeated state labels: forward decoding works ...
+            _ddp_s = DiscreteDP(R, Q, beta; state_values=[:lo, :lo])
+            _res_s = solve(_ddp_s, PFI)
+            @test sigma_values(_res_s) == _res_s.sigma
+            @test simulate(_res_s.mc, 3; init=1) isa Vector{Symbol}
+
+            # ... inversion fails at the earliest moment it can know
+            _err = try
+                DDPPolicyFunction(_res_s)
+            catch _e
+                _e
+            end
+            @test _err isa ArgumentError
+            @test occursin("repeated", _err.msg)
+            @test occursin("sigma_values", _err.msg)
+            @test_throws ArgumentError DDPValueFunction(_res_s)
+            @test_throws ArgumentError state_to_index(_ddp_s, :lo)
+        end
+    end
+
 end # end @testset

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -132,4 +132,45 @@
 
     end
 
+    @testset "IndexMap" begin
+        @testset "vector of tuples" begin
+            vals = [(0.0, 0.1), (1.0, 0.1), (0.0, 1.0), (1.0, 1.0)]
+            im = IndexMap(vals)
+            @test length(im) == 4
+            for (i, v) in enumerate(vals)
+                @test (@inferred im[v]) == i
+                @test vals[im[v]] === v
+            end
+            @test_throws ArgumentError im[(2.0, 0.1)]
+        end
+
+        @testset "isequal semantics" begin
+            im = IndexMap([1, 2, 3])
+            @test im[2.0] == 2  # isequal(2.0, 2)
+            @test_throws ArgumentError im[2.5]
+        end
+
+        @testset "uniqueness required" begin
+            @test_throws ArgumentError IndexMap([:a, :b, :a])
+            # buffer-reuse trap: n aliases of one array collapse the map
+            buf = [0.0]
+            aliased = [buf, buf]
+            @test_throws ArgumentError IndexMap(aliased)
+        end
+
+        @testset "unit-range specialization" begin
+            im = IndexMap(1:5)
+            @test im.dict === nothing
+            @test (@inferred im[3]) == 3
+            @test_throws ArgumentError im[0]
+            @test_throws ArgumentError im[6]
+            @test_throws ArgumentError im[2.5]
+            @test im[2.0] == 2
+
+            im_shift = IndexMap(5:9)
+            @test im_shift[7] == 3
+            @test im_shift.vals[im_shift[7]] == 7
+        end
+    end
+
 end

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -171,6 +171,26 @@
             @test im_shift[7] == 3
             @test im_shift.vals[im_shift[7]] == 7
         end
+
+        @testset "unit-range lookup semantics match the dict path" begin
+            im = IndexMap(0:2)
+            @test im[0] == 1
+            @test im[0.0] == 1
+            # isequal(-0.0, 0) is false: both representations must miss
+            @test_throws ArgumentError im[-0.0]
+            @test_throws ArgumentError IndexMap(collect(0:2))[-0.0]
+            # non-numeric misses raise the documented error, not a
+            # MethodError from the absent dict
+            @test_throws ArgumentError im[:missing]
+            @test_throws ArgumentError im[2.5]
+
+            # ranges whose values exceed Int, but whose offsets fit
+            lo = big(typemax(Int)) + 1
+            im_big = IndexMap(lo:(lo + 2))
+            @test im_big[lo] == 1
+            @test im_big[lo + 2] == 3
+            @test_throws ArgumentError im_big[lo - 1]
+        end
     end
 
 end

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -191,6 +191,22 @@
             @test im_big[lo + 2] == 3
             @test_throws ArgumentError im_big[lo - 1]
         end
+
+        @testset "unit-range offset does not overflow narrow eltypes" begin
+            # the offset must not be computed in the range eltype: the
+            # Int8 offset 255 wraps in Int8 arithmetic
+            im8 = IndexMap(typemin(Int8):typemax(Int8))
+            @test im8[typemin(Int8)] == 1
+            @test im8[typemax(Int8)] == 256
+
+            imu = IndexMap(UInt8(250):UInt8(255))
+            @test imu[UInt8(255)] == 6
+            @test_throws ArgumentError imu[UInt8(3)]
+
+            imb = IndexMap(false:true)
+            @test imb[true] == 2
+            @test_throws ArgumentError imb[2]
+        end
     end
 
 end


### PR DESCRIPTION
Closes #120 (cf. QuantEcon/QuantEcon.py#248), implementing `state_values`/`action_values` on `DiscreteDP` together with the decode layer from the #398 plan. Built on top of #401, whose concretely-typed result parameters are what make the decode layer inferable.

- **New fields**: `DiscreteDP` gains `state_values` and `action_values` fields (two appended type parameters), settable via keywords on both outer constructors with identity-range defaults (`1:n`, `1:m`), following the `MarkovChain` precedent. The fields are decoration: values are labels, not identifiers, so neither field requires uniqueness — repeated action values are shared display labels over distinct action identities, and repeated state values act as observable-level annotation; uniqueness is demanded only by the operations that invert (see below). `state_values` is validated to length `n` exactly; the length of `action_values` defines the number of actions `m`, with `maximum(a_indices) <= m` in the state-action pair formulation, so a universal action set that strictly contains the feasible actions is representable in both formulations. The form converters thread both fields, and `to_product_form` restores `m` from `length(action_values)`, so actions that are feasible nowhere now survive the dense ↔ SA round trip.
- **`IndexMap`** (src/util.jl, exported) is a generic value-to-index map: uniqueness-validated at construction (which also catches generator buffer reuse), informative errors on missing values, `isequal`/`hash` lookup semantics, and a dict-free specialization for `AbstractUnitRange` so identity defaults pay nothing. It is the persistent counterpart of `Base.indexin` — `indexin` builds the same value-to-first-index dictionary internally on every call, with silent first-match and `nothing`-on-miss semantics — promoted to a build-once object with the silent behaviors replaced by errors. Not to be confused with `StatsBase.indexmap` (a QuantEcon dependency), which returns a bare `Dict` with the opposite duplicates policy (silent first occurrence); `IndexMap` rejects duplicated values at construction.
- **Decode layer** (all exported): `sigma_values(res)` returns the optimal policy decoded to action values, pairing with `res.ddp.state_values`; `state_to_index(ddp, s)` is the one-off inverse lookup, throwing informatively on absent and on ambiguous values; `DDPPolicyFunction(res)` and `DDPValueFunction(res)` are callable, value-keyed policy/value functions that pre-validate uniqueness of `state_values` at construction with an error message pointing to the forward-decoding alternatives, and a shared `im` keyword lets both functors reuse one map. `MarkovChain(ddp, sigma)` now attaches `ddp.state_values` to the controlled chain, so `res.mc` and simulated paths decode themselves. All decode paths are type-stable (tested with `@inferred`).
- **Breaking change** for the release notes: `DiscreteDP` gains two type parameters, which breaks exhaustive `DiscreteDP{T,NQ,NR,Tbeta,Tind,TQ}` annotations; partial forms, `isa`/dispatch, and all existing constructor calls keep working.
- **Lecture compatibility**: for the two lectures using `DiscreteDP` ([discrete_dp](https://julia.quantecon.org/dynamic_programming/discrete_dp.html) and [aiyagari](https://julia.quantecon.org/multi_agent_models/aiyagari.html)), **no change is needed** — on their call surface this PR is purely additive. Both construct `DiscreteDP` positionally (unchanged), the new fields are keyword-only with identity defaults, and `res.mc` carries `state_values = 1:n` by default, exactly what `MarkovChain(p)` attached before (same values, same type). The type-parameter extension affects only explicit `DiscreteDP{...}` annotations, which neither lecture writes; the one visible difference is cosmetic — an unsuppressed `DiscreteDP(...)` display prints two additional type parameters.

As a concrete illustration of what the new API offers, here is what an update of the Aiyagari lecture would look like (verified to produce identical `R`, `Q`, solution, and decoded policy). The lecture's `Household` maintains a parallel index matrix `s_i_vals = gridmake(1:a_size, 1:z_size)` and fills `Q` with an O(n·m·n) scan searching for the entries to set:

```julia
    s_vals = gridmake(a_vals, z_chain.state_values)
    s_i_vals = gridmake(1:a_size, 1:z_size)

    Q = zeros(n, a_size, n)
    for next_s_i in 1:size(Q, 3)
        for a_i in 1:size(Q, 2)
            for s_i in 1:size(Q, 1)
                z_i = s_i_vals[s_i, 2]
                next_z_i = s_i_vals[next_s_i, 2]
                next_a_i = s_i_vals[next_s_i, 1]
                if next_a_i == a_i
                    Q[s_i, a_i, next_s_i] = z_chain.p[z_i, next_z_i]
                end
            end
        end
    end
```

and decodes the optimal policy by inverting the flattening formula, an unchecked ordering invariant:

```julia
a_star = reshape([a_vals[results.sigma[s_i]] for s_i in 1:n], a_size, z_size)
```

With this PR, the whole flow becomes value-driven — states are `(a, z)` tuples, `IndexMap` replaces the index matrix, the `Q` entries are written where they belong instead of searched for (an O(n·m·z_size) fill), and decoding queries the policy by state values, agnostic to the enumeration order:

```julia
using QuantEcon

function Household(; r = 0.01,
                   w = 1.0,
                   sigma = 1.0,
                   beta = 0.96,
                   z_chain = MarkovChain([0.9 0.1; 0.1 0.9], [0.1; 1.0]),
                   a_min = 1e-10,
                   a_max = 18.0,
                   a_size = 200,
                   a_vals = range(a_min, a_max, length = a_size),
                   u = sigma == 1 ? x -> log(x) :
                       x -> (x^(1 - sigma) - 1) / (1 - sigma))

    z_vals = z_chain.state_values
    s_vals = vec([(a, z) for a in a_vals, z in z_vals])   # a varies fastest
    im = IndexMap(s_vals)          # (a_new, z_new) -> next-state index
    zi = IndexMap(z_vals)          # z -> row of z_chain.p

    n = length(s_vals)
    R = fill(-Inf, n, a_size)
    Q = zeros(n, a_size, n)
    for (s_i, (a, z)) in enumerate(s_vals), (a_i, a_new) in enumerate(a_vals)
        c = w * z + (1 + r) * a - a_new
        if c > 0
            R[s_i, a_i] = u(c)
        end
        for (next_z_i, z_new) in enumerate(z_vals)
            Q[s_i, a_i, im[(a_new, z_new)]] = z_chain.p[zi[z], next_z_i]
        end
    end
    return (; r, w, sigma, beta, z_chain, a_vals, u, R, Q, s_vals)
end

am = Household(; a_max = 20.0, r = 0.03, w = 0.956)
am_ddp = DiscreteDP(am.R, am.Q, am.beta;
                    state_values = am.s_vals, action_values = am.a_vals)
results = solve(am_ddp, PFI)

a_vals = am.a_vals
z_vals = am.z_chain.state_values
pf = DDPPolicyFunction(results)               # (a, z) -> next period assets
a_star = [pf((a, z)) for a in a_vals, z in z_vals]
```

The plotting code below these lines is unchanged (`a_star` has the same shape and contents); `a_star = reshape(sigma_values(results), a_size, :)` is the equivalent one-line table decode.

Cross-reference to QuantEcon.py: the sibling issue is QuantEcon/QuantEcon.py#248, and the semantics here (index-primary decoration, no uniqueness requirement on the fields, `m` defined by `len(action_values)`, the dense/SA validation pair, conversion invariance) are intended to transfer there unchanged.

Behavior-preserving for solutions: no solution values, iteration counts, or convergence criteria change; construction with defaulted keywords produces models identical to before.

A worked example is included (`examples/ifp_transient_shocks.jl`): the transient-income-shocks IFP of [ifp_egm_transient_shocks](https://python.quantecon.org/ifp_egm_transient_shocks.html) tabulated with the new API — value-typed `(a, z)` states, `IndexMap`-based construction, quadrature plus Young's lottery for the off-grid asset transitions, both dense and sparse formulations, and figures produced from the self-decoding result (`DDPPolicyFunction`, `state_values` on `res.mc`). The example requires Plots, which is not a package dependency.

Verified: full test suite, the four validation scenarios in the repository instructions, the benchmark build check, and a clean docs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
