### PR TITLE
FIX: Run the DDP solver iterations in the promoted Bellman value type

### DIFF
--- a/src/markov/ddp.jl
+++ b/src/markov/ddp.jl
@@ -514,6 +514,11 @@ Object for retaining results and associated metadata after solving the model.
 Returned by `solve`; immutable and constructed complete (the contents of the
 array fields may still be mutated).
 
+The value element type `Tval` is the promoted Bellman value type
+`promote_type(eltype(ddp.R), eltype(v_init), typeof(ddp.beta))`, in which the
+solution methods run: for mixed-precision models (e.g. `Float32` rewards with
+a `Float64` `beta`) it is wider than the reward element type.
+
 # Fields
 
 - `ddp::DiscreteDP`: The model solved. Held by reference, not copied: if the
@@ -804,7 +809,7 @@ function _default_v_init(ddp::DiscreteDP, ::Type{MPFI})
 end
 
 """
-    backward_induction(ddp, J[, v_term=zeros(num_states(ddp))])
+    backward_induction(ddp, J[, v_term=zeros(T, num_states(ddp))])
 
 Solve by backward induction a ``J``-period finite horizon discrete dynamic 
 program with stationary reward ``r`` and transition probability functions ``q``
@@ -826,14 +831,20 @@ and
             \\quad (s \\in S)
 ```
 
-for ``j= J, \\ldots, 1``, where the terminal value function ``v_{J+1}`` is 
+for ``j= J, \\ldots, 1``, where the terminal value function ``v_{J+1}`` is
 exogenously given by `v_term`.
+
+The value functions are computed and stored in the promoted element type
+of ``r + \\beta (q v)``, also incorporating `eltype(v_term)`, so that the
+intermediate value functions of mixed-precision models (e.g. `Float32`
+rewards with a `Float64` discount factor) are not rounded between
+periods.
 
 # Arguments
 
 - `ddp::DiscreteDP{T}`: Object that contains the model parameters.
 - `J::Integer`: Number of decision periods.
-- `v_term::AbstractVector{<:Real}=zeros(num_states(ddp))`: Terminal value 
+- `v_term::AbstractVector{<:Real}=zeros(T, num_states(ddp))`: Terminal value
   function of length equal to n (the number of states).
 
 # Returns
@@ -846,9 +857,9 @@ exogenously given by `v_term`.
 """
 function backward_induction(ddp::DiscreteDP{T}, J::Integer,
                             v_term::AbstractVector{<:Real}=
-                            zeros(num_states(ddp))) where {T}
+                            zeros(T, num_states(ddp))) where {T}
     n = num_states(ddp)
-    S = typeof(zero(T)/one(T))
+    S = promote_type(typeof(zero(T)/one(T)), _bellman_eltype(ddp, v_term))
     vs = Matrix{S}(undef, n, J+1)
     vs[:,end] = v_term
     sigmas = Matrix{Int}(undef, n, J)

--- a/src/markov/ddp.jl
+++ b/src/markov/ddp.jl
@@ -586,10 +586,19 @@ function bellman_operator!(
         ddp::DiscreteDP, v::AbstractVector, Tv::AbstractVector,
         sigma::AbstractVector
     )
-    vals = similar(ddp.R, promote_type(eltype(ddp.R), eltype(v),
-                                       typeof(ddp.beta)))
+    vals = similar(ddp.R, _bellman_eltype(ddp, v))
     bellman_operator!(ddp, v, Tv, sigma, vals)
 end
+
+# Element type of the Bellman values R + beta * (Q v) under promotion.
+# Both the value iterates and the state-action value buffers must use
+# this type, not eltype(v) or eltype(R) alone: with mixed-precision
+# models (e.g. Float32 rewards with a Float64 beta), a narrower buffer
+# rounds near-tied action values to equality before the argmax, and a
+# narrower value iterate stalls short of the fixed point, either of
+# which can flip the policy via the first-action tie-break (issue #403).
+_bellman_eltype(ddp::DiscreteDP, v::AbstractVector) =
+    promote_type(eltype(ddp.R), eltype(v), typeof(ddp.beta))
 
 # Method with a preallocated buffer `vals` (of the same shape as `ddp.R`)
 # for the state-action values; used by the solution methods to avoid
@@ -766,8 +775,10 @@ function _solve(ddp::DiscreteDP{T}, v_init::AbstractVector,
                 ::Type{Algo}, max_iter::Integer, epsilon::Real,
                 k::Integer) where {Algo<:DDPAlgorithm,T}
     # copy the input so that the caller's array is not overwritten by
-    # the solution methods
-    v = Vector{T}(undef, length(v_init))
+    # the solution methods; the iteration runs in the promoted Bellman
+    # value type (see _bellman_eltype), as QuantEcon.py does under NumPy
+    # promotion rules
+    v = Vector{_bellman_eltype(ddp, v_init)}(undef, length(v_init))
     copyto!(v, v_init)
     Tv = similar(v)
     sigma = similar(v, Int)
@@ -1496,7 +1507,7 @@ function _solve!(
         tol = epsilon * (1-ddp.beta) / (2*ddp.beta)
     end
 
-    vals = similar(ddp.R, eltype(v))  # buffer for state-action values
+    vals = similar(ddp.R, _bellman_eltype(ddp, v))  # state-action values
 
     num_iter = 0
     for i in 1:max_iter
@@ -1555,13 +1566,7 @@ function _solve!(
         throw(ArgumentError("method invalid for beta = 1"))
     end
 
-    # buffer for state-action values, in the same promoted element type
-    # as allocated by the 4-arg bellman_operator! method that the greedy
-    # step used to go through: with mixed-precision models (e.g. Float32
-    # rewards with a Float64 beta), a buffer in eltype(v) would round
-    # near-tied action values to equality before the argmax
-    vals = similar(ddp.R, promote_type(eltype(ddp.R), eltype(v),
-                                       typeof(ddp.beta)))
+    vals = similar(ddp.R, _bellman_eltype(ddp, v))  # state-action values
 
     num_iter = 0
     for i in 1:max_iter
@@ -1623,7 +1628,7 @@ function _solve!(
 
     tol = beta > 0 ? epsilon * (1-beta) / beta : Inf
 
-    vals = similar(ddp.R, eltype(v))  # buffer for state-action values
+    vals = similar(ddp.R, _bellman_eltype(ddp, v))  # state-action values
     dif = similar(v)
 
     num_iter = 0

--- a/test/test_ddp.jl
+++ b/test/test_ddp.jl
@@ -659,13 +659,14 @@ Tests for markov/ddp.jl
             @test QuantEcon._max_abs_diff([1.0, 3.0], [0.0, 0.0]) == 3.0
         end
 
-        @testset "PFI argmax with mixed precision" begin
-            # the state-action value buffer of the PFI greedy step must
+        @testset "solver argmax with mixed precision" begin
+            # the state-action value buffers of the solver loops must
             # use the promoted element type, not eltype(v): with Float32
             # rewards and a Float64 beta, the two actions at state 1 are
             # near-tied (~1e-11 apart at ~10), distinguishable in Float64
             # but rounded to equality in Float32, where the first-action
-            # tie-break would flip the policy to [1, 1]
+            # tie-break would flip the policy to [1, 1] (issue #403; the
+            # PFI case is the #401 regression)
             _R_mp = Float32[1.0 -8.0; 2.0 2.0]
             _Q_mp = zeros(Float32, 2, 2, 2)
             _Q_mp[1, 1, 1] = 1.0
@@ -674,6 +675,10 @@ Tests for markov/ddp.jl
             _Q_mp[2, 2, 2] = 1.0
             _ddp_mp = DiscreteDP(_R_mp, _Q_mp, 0.900000000001)
             @test solve(_ddp_mp, PFI).sigma == [2, 1]
+            @test solve(_ddp_mp, VFI;
+                        max_iter=100_000, epsilon=1e-10).sigma == [2, 1]
+            @test solve(_ddp_mp, MPFI;
+                        max_iter=100_000, epsilon=1e-10).sigma == [2, 1]
         end
 
         @testset "s_wise_max! argmax with mixed precision" begin

--- a/test/test_ddp.jl
+++ b/test/test_ddp.jl
@@ -674,11 +674,27 @@ Tests for markov/ddp.jl
             _Q_mp[2, 1, 2] = 1.0
             _Q_mp[2, 2, 2] = 1.0
             _ddp_mp = DiscreteDP(_R_mp, _Q_mp, 0.900000000001)
-            @test solve(_ddp_mp, PFI).sigma == [2, 1]
-            @test solve(_ddp_mp, VFI;
-                        max_iter=100_000, epsilon=1e-10).sigma == [2, 1]
-            @test solve(_ddp_mp, MPFI;
-                        max_iter=100_000, epsilon=1e-10).sigma == [2, 1]
+            for _Algo in (PFI, VFI, MPFI)
+                _res_mp = solve(_ddp_mp, _Algo;
+                                max_iter=100_000, epsilon=1e-10)
+                @test _res_mp.sigma == [2, 1]
+                # the result carries the promoted value type
+                @test eltype(_res_mp.v) === Float64
+                @test eltype(_res_mp.Tv) === Float64
+            end
+
+            # finite horizon: the value array must be promoted likewise,
+            # or the intermediate value functions are rounded to Float32
+            # between periods and stall short of the same near-tie
+            _vs_mp, _sigmas_mp = backward_induction(_ddp_mp, 241)
+            @test eltype(_vs_mp) === Float64
+            @test _sigmas_mp[:, 1] == [2, 1]
+
+            # homogeneous models keep their element type: no silent
+            # widening when beta matches the data
+            _ddp_32 = DiscreteDP(_R_mp, _Q_mp, 0.9f0)
+            @test eltype(solve(_ddp_32, PFI).v) === Float32
+            @test eltype(backward_induction(_ddp_32, 3)[1]) === Float32
         end
 
         @testset "s_wise_max! argmax with mixed precision" begin


### PR DESCRIPTION
Closes #403. The VFI and MPFI loops computed and stored Bellman values in `eltype(v)`, the reward element type, and `backward_induction` likewise allocated its value array from the reward type alone: for mixed-precision models (e.g. `Float32` rewards and transitions with a `Float64` `beta`), near-tied action values rounded to equality before the maximization and were resolved by the first-action tie-break, selecting a policy that promoted arithmetic would not (see the reproducer in #403, on which VFI and MPFI returned `[1, 1]` against the correct `[2, 1]`; `backward_induction` returns the same wrong first-period policy at `J = 241`).

**The fix goes one step beyond the workspace promotion proposed in #403, which implementation showed to be insufficient.** With the iterate `v` itself kept narrow, the value iteration stalls at the fixed point of the *rounded* iteration map rather than the true one (on the reproducer: `(9.999996f0, 19.999992f0)` after 138 iterations, ~3e-6 short of `v* ≈ (10.0000000001, 20.0000000002)`), and at that stalled point the exact argmax legitimately differs — the 1e-11 near-tie only exists at the true fixed point, below `Float32` resolution near those magnitudes. Promoting the workspaces alone therefore left VFI and MPFI at `[1, 1]` (verified). PFI was unaffected only by luck: its `v` comes from an exact linear solve, and the `Float32` rounding of `v*` happens to preserve the argmax.

The change:

- `_solve` now allocates `v` — and thereby `Tv` and every buffer typed from `eltype(v)` — at the promoted Bellman value type `promote_type(eltype(R), eltype(v_init), typeof(beta))`. This also makes MPFI's inner policy-evaluation loop (`mul!(Tv, Q_sigma, v)`), the second surface identified in #403, accumulate in the promoted type with no further change.
- The rule is centralized in a new internal helper `_bellman_eltype(ddp, v)`, now used by the allocating `bellman_operator!` method, the PFI buffer from #401, and the VFI/MPFI state-action buffers; the type computation constant-folds, so there is no runtime cost.
- `backward_induction` allocates its value array at `promote_type(typeof(zero(T)/one(T)), _bellman_eltype(ddp, v_term))`, and its `v_term` default changes from `zeros(num_states(ddp))` to `zeros(T, num_states(ddp))`: respecting `eltype(v_term)` must not widen homogeneous non-`Float64` or rational models through a synthetic `Float64` default. Resulting rules, pinned by tests: `Float32` data with a `Float32` `beta` stays `Float32`; `Float32` data with a `Float64` `beta` runs in `Float64`; rational models keep exact rational arithmetic by default; an explicitly wider `v_term` is not narrowed.
- The mixed-precision regression testset from #401 now covers all three infinite-horizon algorithms (policies and the promoted `res.v`/`res.Tv` element types) and `backward_induction` on the same reproducer; the `Tval` rule is documented in the `DPSolveResult` docstring.

**Behavior changes** (mixed-precision models only; homogeneous models, including all-`Float32` models with a `Float32` `beta`, are bit-for-bit unaffected since `promote_type` is the identity there):

1. Argmax near-ties may resolve differently than in released versions (correctly, per promoted arithmetic).
2. `res.v` and `res.Tv` are returned in the promoted type (e.g. `Float64` for `Float32` rewards with a `Float64` `beta`), so `DPSolveResult`'s `Tval` parameter is the promoted type. This matches what QuantEcon.py returns: NumPy computes `R + beta * (Q @ v)` under promotion rules, so its `v` is `float64` from the first iteration. Nothing to fix on the Python side.
3. VFI on mixed-precision models may run more iterations than before: the narrow iterate used to stall at `Float32` resolution (reaching `err == 0` exactly), while the promoted iterate keeps contracting to the requested tolerance (138 -> 253 iterations on the reproducer).
4. `backward_induction` returns its value array in the promoted type as well (first-period policies may differ correctly, as above); with the `T`-typed `v_term` default, homogeneous and rational models are unaffected.

**Benchmarks** (all-`Float64` models, where the generated code is unchanged): two full `judge` runs of the suite against `master` (f855cda) show memory ratios of exactly 1.00 on every key in both runs; the time-ratio flags scatter in both directions and do not replicate across the runs — e.g. `["ddp", "sa_sparse_n3000_m50_k5", "solve_PFI"]` flips from 0.76 to 1.08, `["ddp", "dense_n500_m100", "evaluate_policy"]` from 0.86 to 1.19, run 1's 1.20 on `["ddp", "dense_n500_m100", "solve_MPFI"]` disappears in run 2, and run 2 flags `["mc_tools", "simulate", "dense_n1000_ts100"]` (1.37), which this commit does not touch — i.e. machine noise under background load, not a performance change.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
