### PR TITLE
ENH: Add the POMDPs.jl extension for DiscreteDP

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,13 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
+[weakdeps]
+POMDPTools = "7588e00f-9cae-40de-98dc-e0c70c48cdd7"
+POMDPs = "a93abf59-7444-517b-a68a-c42f96afdd7d"
+
+[extensions]
+QuantEconPOMDPsExt = ["POMDPs", "POMDPTools"]
+
 [compat]
 DSP = "0.6, 0.7, 0.8"
 DataStructures = "0.18, 0.19"
@@ -26,6 +33,8 @@ FFTW = "1"
 Graphs = "1.6, 1.7, 1.8, 1.9"
 NLopt = "0.5, 0.6, 1"
 Optim = "1, 2"
+POMDPTools = "1"
+POMDPs = "1"
 Primes = "0.4, 0.5"
 SpecialFunctions = "1, 2"
 Statistics = "1"
@@ -34,8 +43,10 @@ julia = "1.10"
 
 [extras]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+POMDPTools = "7588e00f-9cae-40de-98dc-e0c70c48cdd7"
+POMDPs = "a93abf59-7444-517b-a68a-c42f96afdd7d"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DataStructures", "Pkg", "Test"]
+test = ["DataStructures", "POMDPs", "POMDPTools", "Pkg", "Test"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,5 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+POMDPTools = "7588e00f-9cae-40de-98dc-e0c70c48cdd7"
+POMDPs = "a93abf59-7444-517b-a68a-c42f96afdd7d"
 QuantEcon = "fcd29c91-0bd7-5a09-975d-7ac3f643a60c"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,14 +1,18 @@
 using Documenter, QuantEcon
+using POMDPs, POMDPTools  # trigger packages of QuantEconPOMDPsExt
+
+const QuantEconPOMDPsExt = Base.get_extension(QuantEcon, :QuantEconPOMDPsExt)
 
 makedocs(
-    modules = [QuantEcon],
+    modules = [QuantEcon, QuantEconPOMDPsExt],
     format = Documenter.HTML(prettyurls = false, size_threshold = nothing),
     sitename = "QuantEcon.jl",
     pages = Any[ # Compat: `Any` for 0.4 compat
         "Home" => "index.md",
         # "User Guide" => "man/guide.md",
         "API" => Any[
-            "QuantEcon" => "api/QuantEcon.md"
+            "QuantEcon" => "api/QuantEcon.md",
+            "QuantEconPOMDPsExt" => "api/QuantEconPOMDPsExt.md"
         ],
         "Contributing" => "man/contributing.md"
     ]

--- a/docs/src/api/QuantEconPOMDPsExt.md
+++ b/docs/src/api/QuantEconPOMDPsExt.md
@@ -1,0 +1,32 @@
+# QuantEconPOMDPsExt
+
+```@meta
+CurrentModule = QuantEconPOMDPsExt
+```
+
+API documentation for the POMDPs.jl integration, a package extension
+activated by loading both trigger packages alongside QuantEcon:
+
+```julia
+using QuantEcon
+using POMDPs, POMDPTools
+```
+
+Note that `solve` must then be qualified (`QuantEcon.solve` or
+`POMDPs.solve`), as both packages export it.
+
+```@contents
+Pages = ["QuantEconPOMDPsExt.md"]
+```
+
+## Index
+
+```@index
+Pages = ["QuantEconPOMDPsExt.md"]
+```
+
+## Interface
+
+```@autodocs
+Modules = [QuantEconPOMDPsExt]
+```

--- a/ext/QuantEconPOMDPsExt.jl
+++ b/ext/QuantEconPOMDPsExt.jl
@@ -68,7 +68,15 @@ unique, value-hashable objects; `actions(m, s)` defines the feasible
 set at `s`; rewards are the expected `reward(m, s, a, sp)` under
 `transition(m, s, a)` (3-argument models are covered by the POMDPs.jl
 fallback); states with `isterminal(m, s)` are encoded as zero-reward
-self-loops, so their value is exactly zero.
+self-loops under every action in `actions(m)`, so their value is
+exactly zero (`actions(m, s)` is not consulted at terminal states, so
+it may be empty there).
+
+Rewards and transition probabilities are normalized to `Float64`,
+whatever the model's numerical element types. Transition weights are
+taken from `transition(m, s, a)` as-is, with only exactly-zero branches
+dropped: their validity (nonnegativity, summing to one) is the model's
+responsibility, as it is the caller's in the native constructors.
 """
 function QuantEcon.DiscreteDP(m::POMDPs.MDP;
                               sparse::Val{S}=Val(true)) where {S}
@@ -90,11 +98,13 @@ function _tabulate(m::POMDPs.MDP, svals, smap, avals, amap, bet,
     L = 0
     for (s_i, s) in enumerate(svals)
         if POMDPs.isterminal(m, s)
-            # zero-reward self-loop for every feasible action
-            for a in POMDPs.actions(m, s)
+            # zero-reward self-loop under every global action;
+            # actions(m, s) is not consulted (it may be empty at a
+            # terminal state)
+            for a_i in eachindex(avals)
                 L += 1
                 push!(s_indices, s_i)
-                push!(a_indices, _action_index(amap, s, a))
+                push!(a_indices, a_i)
                 push!(R, 0.0)
                 push!(QI, L); push!(QJ, s_i); push!(QV, 1.0)
             end
@@ -105,7 +115,7 @@ function _tabulate(m::POMDPs.MDP, svals, smap, avals, amap, bet,
                 push!(a_indices, _action_index(amap, s, a))
                 r_sa = 0.0
                 for (sp, w) in weighted_iterator(POMDPs.transition(m, s, a))
-                    w > 0 || continue
+                    iszero(w) && continue
                     sp_i = _next_state_index(smap, s, a, sp)
                     push!(QI, L); push!(QJ, sp_i); push!(QV, w)
                     r_sa += w * POMDPs.reward(m, s, a, sp)
@@ -128,17 +138,20 @@ function _tabulate(m::POMDPs.MDP, svals, smap, avals, amap, bet,
     R = fill(-Inf, n, length(avals))
     Q = zeros(n, length(avals), n)
     for (s_i, s) in enumerate(svals)
-        for a in POMDPs.actions(m, s)
-            a_i = _action_index(amap, s, a)
-            isinf(R[s_i, a_i]) || throw(ArgumentError(
-                "actions(m, s) at state $s yields the duplicate action $a"))
-            if POMDPs.isterminal(m, s)
-                R[s_i, a_i] = 0.0
-                Q[s_i, a_i, s_i] = 1.0
-            else
+        if POMDPs.isterminal(m, s)
+            # zero-reward self-loop under every global action;
+            # actions(m, s) is not consulted (it may be empty at a
+            # terminal state)
+            R[s_i, :] .= 0.0
+            Q[s_i, :, s_i] .= 1.0
+        else
+            for a in POMDPs.actions(m, s)
+                a_i = _action_index(amap, s, a)
+                isinf(R[s_i, a_i]) || throw(ArgumentError(
+                    "actions(m, s) at state $s yields the duplicate action $a"))
                 r_sa = 0.0
                 for (sp, w) in weighted_iterator(POMDPs.transition(m, s, a))
-                    w > 0 || continue
+                    iszero(w) && continue
                     Q[s_i, a_i, _next_state_index(smap, s, a, sp)] += w
                     r_sa += w * POMDPs.reward(m, s, a, sp)
                 end

--- a/ext/QuantEconPOMDPsExt.jl
+++ b/ext/QuantEconPOMDPsExt.jl
@@ -1,0 +1,232 @@
+#=
+POMDPs.jl integration for DiscreteDP (issue #398).
+
+Model import: `DiscreteDP(m::POMDPs.MDP)` tabulates an explicit-finite
+POMDPs.jl model into a `DiscreteDP` in state-action pair form, and
+`POMDPs.solve(DiscreteDPSolver(algo), m)` solves it and wraps the
+result as a `POMDPs.Policy`.
+
+Model export: `as_mdp(ddp)` exposes a `DiscreteDP` as a `POMDPs.MDP`.
+It is internal, testing-grade round-trip infrastructure; its public
+naming is deferred. Reach it via
+`Base.get_extension(QuantEcon, :QuantEconPOMDPsExt).as_mdp`.
+=#
+module QuantEconPOMDPsExt
+
+# selective imports only: the exported core names DiscreteDPSolver and
+# solve must not enter this namespace unqualified (the former is
+# shadowed by the local struct below, the latter collides with
+# POMDPs.solve)
+using QuantEcon: QuantEcon, DiscreteDP, DDPAlgorithm, VFI, PFI, MPFI,
+                 DPSolveResult, IndexMap, DDPPolicyFunction,
+                 DDPValueFunction, to_sa_pair_form
+using POMDPs: POMDPs
+using POMDPTools: weighted_iterator, SparseCat
+using SparseArrays: sparse
+
+# ------------ #
+# Model import #
+# ------------ #
+
+function _next_state_index(smap::IndexMap, s, a, sp)
+    try
+        return smap[sp]
+    catch
+        throw(ArgumentError("transition at state $s under action $a " *
+            "yields next state $sp, which is not in states(m): the " *
+            "state space must be closed under transitions"))
+    end
+end
+
+function _action_index(amap::IndexMap, s, a)
+    try
+        return amap[a]
+    catch
+        throw(ArgumentError("actions(m, s) at state $s yields action " *
+            "$a, which is not in actions(m): per-state action sets " *
+            "must be subsets of the global action space"))
+    end
+end
+
+"""
+    DiscreteDP(m::POMDPs.MDP)
+
+Tabulate an explicit-finite POMDPs.jl model into a `DiscreteDP` in
+state-action pair form, with `state_values = vec(collect(states(m)))`
+and `action_values = vec(collect(actions(m)))` attached.
+
+The importer is index-free: it enumerates `states(m)` and `actions(m)`
+and builds its own value-to-index maps, so `stateindex`/`actionindex`
+and `initialstate` are not consumed. States and actions must enumerate
+unique, value-hashable objects; `actions(m, s)` defines the feasible
+set at `s`; rewards are the expected `reward(m, s, a, sp)` under
+`transition(m, s, a)` (3-argument models are covered by the POMDPs.jl
+fallback); states with `isterminal(m, s)` are encoded as zero-reward
+self-loops, so their value is exactly zero.
+"""
+function QuantEcon.DiscreteDP(m::POMDPs.MDP)
+    svals = vec(collect(POMDPs.states(m)))
+    smap = IndexMap(svals)     # also rejects duplicate/aliased states
+    avals = vec(collect(POMDPs.actions(m)))
+    amap = IndexMap(avals)
+    bet = POMDPs.discount(m)
+
+    s_indices = Int[]; a_indices = Int[]; R = Float64[]
+    QI = Int[]; QJ = Int[]; QV = Float64[]
+    L = 0
+    for (s_i, s) in enumerate(svals)
+        if POMDPs.isterminal(m, s)
+            # zero-reward self-loop for every feasible action
+            for a in POMDPs.actions(m, s)
+                L += 1
+                push!(s_indices, s_i)
+                push!(a_indices, _action_index(amap, s, a))
+                push!(R, 0.0)
+                push!(QI, L); push!(QJ, s_i); push!(QV, 1.0)
+            end
+        else
+            for a in POMDPs.actions(m, s)
+                L += 1
+                push!(s_indices, s_i)
+                push!(a_indices, _action_index(amap, s, a))
+                r_sa = 0.0
+                for (sp, w) in weighted_iterator(POMDPs.transition(m, s, a))
+                    w > 0 || continue
+                    sp_i = _next_state_index(smap, s, a, sp)
+                    push!(QI, L); push!(QJ, sp_i); push!(QV, w)
+                    r_sa += w * POMDPs.reward(m, s, a, sp)
+                end
+                push!(R, r_sa)
+            end
+        end
+    end
+    Q = sparse(QI, QJ, QV, L, length(svals))   # duplicate branches summed
+    return DiscreteDP(R, Q, bet, s_indices, a_indices;
+                      state_values=svals, action_values=avals)
+end
+
+# ------ #
+# Solver #
+# ------ #
+
+"""
+    DiscreteDPSolver(algo=VFI; max_iter=250, epsilon=1e-3, k=20)
+
+POMDPs.jl solver based on the `DiscreteDP` solution methods. `algo` is
+one of `VFI`, `PFI`, or `MPFI`; the keyword options are those of
+`solve`. `POMDPs.solve(solver, m)` tabulates `m` via `DiscreteDP(m)`,
+solves it, and returns a `DiscreteDPPolicy`.
+"""
+struct DiscreteDPSolver{Algo<:DDPAlgorithm} <: POMDPs.Solver
+    max_iter::Int
+    epsilon::Float64
+    k::Int
+end
+
+function DiscreteDPSolver(::Type{Algo}=VFI; max_iter::Integer=250,
+                          epsilon::Real=1e-3,
+                          k::Integer=20) where {Algo<:DDPAlgorithm}
+    return DiscreteDPSolver{Algo}(max_iter, epsilon, k)
+end
+
+# the single method extending the core generic; every other use of the
+# bare name in this module refers to the local struct
+QuantEcon.DiscreteDPSolver(args...; kwargs...) =
+    DiscreteDPSolver(args...; kwargs...)
+
+"""
+    DiscreteDPPolicy
+
+Policy returned by `POMDPs.solve(::DiscreteDPSolver, m)`. Supports
+`action(policy, s)` and `value(policy, s)`, queried by state value; the
+native result is reachable as `policy.res`, and `markov_chain(policy)`
+returns the controlled Markov chain.
+
+# Fields
+
+- `m::POMDPs.MDP`: The source model.
+- `pf::DDPPolicyFunction`: Policy function, `s -> optimal action value`.
+- `vf::DDPValueFunction`: Value function, `s -> optimal value`.
+- `res::DPSolveResult`: The native solution.
+
+"""
+struct DiscreteDPPolicy{M<:POMDPs.MDP,TPF<:DDPPolicyFunction,
+                        TVF<:DDPValueFunction,
+                        TR<:DPSolveResult} <: POMDPs.Policy
+    m::M
+    pf::TPF
+    vf::TVF
+    res::TR
+end
+
+function POMDPs.solve(solver::DiscreteDPSolver{Algo},
+                      m::POMDPs.MDP) where {Algo}
+    ddp = QuantEcon.DiscreteDP(m)
+    res = QuantEcon.solve(ddp, Algo; max_iter=solver.max_iter,
+                          epsilon=solver.epsilon, k=solver.k)
+    im = IndexMap(res.ddp.state_values)
+    return DiscreteDPPolicy(m, DDPPolicyFunction(res; im),
+                            DDPValueFunction(res; im), res)
+end
+
+POMDPs.action(p::DiscreteDPPolicy, s) = p.pf(s)
+POMDPs.value(p::DiscreteDPPolicy, s) = p.vf(s)
+QuantEcon.markov_chain(p::DiscreteDPPolicy) = QuantEcon.markov_chain(p.res)
+
+# ----------------------- #
+# Model export (internal) #
+# ----------------------- #
+
+# Expose a DiscreteDP as a POMDPs.MDP. INTERNAL: round-trip and
+# cross-validation test infrastructure; the public naming of this
+# direction is deferred (#398). Works on the state-action pair form,
+# so every DiscreteDP is first converted with to_sa_pair_form.
+struct DDPasMDP{S,A,TD<:DiscreteDP,TSM<:IndexMap,
+                TAM<:IndexMap} <: POMDPs.MDP{S,A}
+    ddp_sa::TD
+    smap::TSM
+    amap::TAM
+end
+
+function as_mdp(ddp::DiscreteDP)
+    dsa = to_sa_pair_form(ddp)
+    smap = IndexMap(dsa.state_values)
+    amap = IndexMap(dsa.action_values)
+    S = eltype(dsa.state_values)
+    A = eltype(dsa.action_values)
+    return DDPasMDP{S,A,typeof(dsa),typeof(smap),typeof(amap)}(dsa, smap,
+                                                               amap)
+end
+
+POMDPs.states(w::DDPasMDP) = w.ddp_sa.state_values
+POMDPs.actions(w::DDPasMDP) = w.ddp_sa.action_values
+
+function POMDPs.actions(w::DDPasMDP, s)
+    d = w.ddp_sa
+    s_i = w.smap[s]
+    return d.action_values[d.a_indices[d.a_indptr[s_i]:(d.a_indptr[s_i+1] - 1)]]
+end
+
+POMDPs.discount(w::DDPasMDP) = w.ddp_sa.beta
+POMDPs.isterminal(w::DDPasMDP, s) = false
+
+function _pair_index(w::DDPasMDP, s, a)
+    d = w.ddp_sa
+    s_i = w.smap[s]
+    a_i = w.amap[a]
+    for j in d.a_indptr[s_i]:(d.a_indptr[s_i+1] - 1)
+        d.a_indices[j] == a_i && return j
+    end
+    throw(ArgumentError("action $a is not feasible at state $s"))
+end
+
+POMDPs.reward(w::DDPasMDP, s, a) = w.ddp_sa.R[_pair_index(w, s, a)]
+
+function POMDPs.transition(w::DDPasMDP, s, a)
+    d = w.ddp_sa
+    probs = Vector(d.Q[_pair_index(w, s, a), :])
+    nz = findall(>(0), probs)
+    return SparseCat(d.state_values[nz], probs[nz])
+end
+
+end # module

--- a/ext/QuantEconPOMDPsExt.jl
+++ b/ext/QuantEconPOMDPsExt.jl
@@ -49,11 +49,17 @@ function _action_index(amap::IndexMap, s, a)
 end
 
 """
-    DiscreteDP(m::POMDPs.MDP)
+    DiscreteDP(m::POMDPs.MDP; sparse=Val(true))
 
-Tabulate an explicit-finite POMDPs.jl model into a `DiscreteDP` in
-state-action pair form, with `state_values = vec(collect(states(m)))`
-and `action_values = vec(collect(actions(m)))` attached.
+Tabulate an explicit-finite POMDPs.jl model into a `DiscreteDP`, with
+`state_values = vec(collect(states(m)))` and
+`action_values = vec(collect(actions(m)))` attached. With
+`sparse=Val(true)` (the default) the result is in state-action pair
+form with a sparse transition matrix; with `sparse=Val(false)` it is in
+dense product form, constructed directly (equivalent to
+`to_product_form` of the sparse import, without the intermediate). The
+keyword is value-typed so that the formulation is determined in the
+type domain.
 
 The importer is index-free: it enumerates `states(m)` and `actions(m)`
 and builds its own value-to-index maps, so `stateindex`/`actionindex`
@@ -64,13 +70,21 @@ set at `s`; rewards are the expected `reward(m, s, a, sp)` under
 fallback); states with `isterminal(m, s)` are encoded as zero-reward
 self-loops, so their value is exactly zero.
 """
-function QuantEcon.DiscreteDP(m::POMDPs.MDP)
+function QuantEcon.DiscreteDP(m::POMDPs.MDP;
+                              sparse::Val{S}=Val(true)) where {S}
+    S isa Bool || throw(ArgumentError(
+        "sparse must be Val(true) or Val(false)"))
     svals = vec(collect(POMDPs.states(m)))
     smap = IndexMap(svals)     # also rejects duplicate/aliased states
     avals = vec(collect(POMDPs.actions(m)))
     amap = IndexMap(avals)
     bet = POMDPs.discount(m)
+    return _tabulate(m, svals, smap, avals, amap, bet, sparse)
+end
 
+# state-action pair form, sparse Q
+function _tabulate(m::POMDPs.MDP, svals, smap, avals, amap, bet,
+                   ::Val{true})
     s_indices = Int[]; a_indices = Int[]; R = Float64[]
     QI = Int[]; QJ = Int[]; QV = Float64[]
     L = 0
@@ -105,28 +119,64 @@ function QuantEcon.DiscreteDP(m::POMDPs.MDP)
                       state_values=svals, action_values=avals)
 end
 
+# dense product form, constructed directly: n and m are known upfront,
+# so the final arrays are the only allocations; infeasible pairs keep
+# the -Inf reward and zero transition row of the dense convention
+function _tabulate(m::POMDPs.MDP, svals, smap, avals, amap, bet,
+                   ::Val{false})
+    n = length(svals)
+    R = fill(-Inf, n, length(avals))
+    Q = zeros(n, length(avals), n)
+    for (s_i, s) in enumerate(svals)
+        for a in POMDPs.actions(m, s)
+            a_i = _action_index(amap, s, a)
+            isinf(R[s_i, a_i]) || throw(ArgumentError(
+                "actions(m, s) at state $s yields the duplicate action $a"))
+            if POMDPs.isterminal(m, s)
+                R[s_i, a_i] = 0.0
+                Q[s_i, a_i, s_i] = 1.0
+            else
+                r_sa = 0.0
+                for (sp, w) in weighted_iterator(POMDPs.transition(m, s, a))
+                    w > 0 || continue
+                    Q[s_i, a_i, _next_state_index(smap, s, a, sp)] += w
+                    r_sa += w * POMDPs.reward(m, s, a, sp)
+                end
+                R[s_i, a_i] = r_sa
+            end
+        end
+    end
+    return DiscreteDP(R, Q, bet; state_values=svals, action_values=avals)
+end
+
 # ------ #
 # Solver #
 # ------ #
 
 """
-    DiscreteDPSolver(algo=VFI; max_iter=250, epsilon=1e-3, k=20)
+    DiscreteDPSolver(algo=VFI; sparse=Val(true), max_iter=250,
+                     epsilon=1e-3, k=20)
 
 POMDPs.jl solver based on the `DiscreteDP` solution methods. `algo` is
-one of `VFI`, `PFI`, or `MPFI`; the keyword options are those of
-`solve`. `POMDPs.solve(solver, m)` tabulates `m` via `DiscreteDP(m)`,
-solves it, and returns a `DiscreteDPPolicy`.
+one of `VFI`, `PFI`, or `MPFI`; `sparse` selects the tabulation
+formulation (`Val(true)` for state-action pair form with sparse
+storage, `Val(false)` for dense product form; value-typed, and carried
+as a type parameter of the solver); the remaining keyword options are
+those of `solve`. `POMDPs.solve(solver, m)` tabulates `m` via
+`DiscreteDP(m)`, solves it, and returns a `DiscreteDPPolicy`.
 """
-struct DiscreteDPSolver{Algo<:DDPAlgorithm} <: POMDPs.Solver
+struct DiscreteDPSolver{Algo<:DDPAlgorithm,S} <: POMDPs.Solver
     max_iter::Int
     epsilon::Float64
     k::Int
 end
 
-function DiscreteDPSolver(::Type{Algo}=VFI; max_iter::Integer=250,
-                          epsilon::Real=1e-3,
-                          k::Integer=20) where {Algo<:DDPAlgorithm}
-    return DiscreteDPSolver{Algo}(max_iter, epsilon, k)
+function DiscreteDPSolver(::Type{Algo}=VFI; sparse::Val{S}=Val(true),
+                          max_iter::Integer=250, epsilon::Real=1e-3,
+                          k::Integer=20) where {Algo<:DDPAlgorithm,S}
+    S isa Bool || throw(ArgumentError(
+        "sparse must be Val(true) or Val(false)"))
+    return DiscreteDPSolver{Algo,S}(max_iter, epsilon, k)
 end
 
 # the single method extending the core generic; every other use of the
@@ -159,9 +209,9 @@ struct DiscreteDPPolicy{M<:POMDPs.MDP,TPF<:DDPPolicyFunction,
     res::TR
 end
 
-function POMDPs.solve(solver::DiscreteDPSolver{Algo},
-                      m::POMDPs.MDP) where {Algo}
-    ddp = QuantEcon.DiscreteDP(m)
+function POMDPs.solve(solver::DiscreteDPSolver{Algo,S},
+                      m::POMDPs.MDP) where {Algo,S}
+    ddp = QuantEcon.DiscreteDP(m; sparse=Val(S))
     res = QuantEcon.solve(ddp, Algo; max_iter=solver.max_iter,
                           epsilon=solver.epsilon, k=solver.k)
     im = IndexMap(res.ddp.state_values)

--- a/ext/examples/ifp_transient_shocks_pomdps.jl
+++ b/ext/examples/ifp_transient_shocks_pomdps.jl
@@ -1,0 +1,111 @@
+#=
+Income fluctuation problem with transient and persistent income shocks,
+implementing the model in
+
+    https://python.quantecon.org/ifp_egm_transient_shocks.html
+
+as a POMDPs.jl model consumed by the QuantEcon POMDPs extension: the
+model states its economics in six interface methods, with the transient
+shock integrated into the transition distribution by Gauss-Hermite
+quadrature and next-period assets assigned to the two bracketing asset
+grid points (Young's method) inside `transition` -- the discretization
+is part of the model. Tabulation into a `DiscreteDP` is done by the
+extension's importer; see examples/ifp_transient_shocks.jl for the
+native construction of the same model.
+
+Note that `solve` must be qualified (`QuantEcon.solve` or
+`POMDPs.solve`), as both packages export it.
+
+The example requires POMDPs, POMDPTools, and Plots, which are not
+package dependencies.
+=#
+
+using QuantEcon, POMDPs, POMDPTools, Plots
+
+struct Household{TA<:AbstractVector,TS<:AbstractVector} <:
+        POMDPs.MDP{Tuple{Float64,Float64},Float64}
+    gamma::Float64; bet::Float64; r::Float64
+    a_y::Float64; b_y::Float64
+    Pi::Matrix{Float64}
+    z_grid::Vector{Float64}
+    a_vals::TA                 # asset states
+    s_grid::TS                 # savings actions
+    eta::Vector{Float64}       # transient shock quadrature nodes
+    w_eta::Vector{Float64}     # and weights
+end
+
+function Household(; gamma=1.5, bet=0.96, r=0.01, a_y=0.2, b_y=0.5,
+                   Pi=[0.6 0.4; 0.05 0.95], z_grid=[-10.0, log(2.0)],
+                   n_nodes=7, a_min=1e-10, a_max=20.0, a_size=800)
+    eta, w_eta = qnwnorm(n_nodes, 0.0, 1.0)
+    return Household(gamma, bet, r, a_y, b_y, Pi, z_grid,
+                     range(a_min, a_max, length=a_size),
+                     range(0.0, a_max, length=a_size), eta, w_eta)
+end
+
+POMDPs.states(hh::Household) = Iterators.product(hh.a_vals, hh.z_grid)
+POMDPs.actions(hh::Household) = hh.s_grid
+POMDPs.actions(hh::Household, s::Tuple) =           # feasible: c > 0
+    (sav for sav in hh.s_grid if s[1] - sav > 0)
+POMDPs.reward(hh::Household, s::Tuple, sav) =       # u(c)
+    (s[1] - sav)^(1 - hh.gamma) / (1 - hh.gamma)
+POMDPs.discount(hh::Household) = hh.bet
+
+# (a_next, z_next): z_next ~ Pi; a_next = R sav + exp(a_y eta + b_y z_next),
+# spread over the two bracketing asset grid points (Young's method)
+function POMDPs.transition(hh::Household, s::Tuple, sav)
+    a_vals = hh.a_vals
+    zi = findfirst(==(s[2]), hh.z_grid)
+    sps = Tuple{Float64,Float64}[]
+    ws = Float64[]
+    for (zp_i, zp) in enumerate(hh.z_grid), l in eachindex(hh.eta)
+        ap = clamp((1 + hh.r) * sav + exp(hh.a_y * hh.eta[l] + hh.b_y * zp),
+                   first(a_vals), last(a_vals))
+        i = min(searchsortedlast(a_vals, ap), length(a_vals) - 1)
+        lam = (ap - a_vals[i]) / (a_vals[i+1] - a_vals[i])
+        w = hh.Pi[zi, zp_i] * hh.w_eta[l]
+        push!(sps, (a_vals[i], zp));   push!(ws, w * (1 - lam))
+        push!(sps, (a_vals[i+1], zp)); push!(ws, w * lam)
+    end
+    return SparseCat(sps, ws)
+end
+
+hh = Household()
+
+# model import: the extension's importer tabulates the model
+res = QuantEcon.solve(DiscreteDP(hh), PFI)
+pf = DDPPolicyFunction(res)                       # (a, z) -> optimal savings
+
+# expected next-period income given current z (row z_i of Pi)
+y_bar(z_i) = sum(hh.Pi[z_i, zp_i] *
+                 sum(hh.w_eta .* exp.(hh.a_y .* hh.eta .+ hh.b_y * zp))
+                 for (zp_i, zp) in enumerate(hh.z_grid))
+
+# current assets vs (expected) next-period assets
+plt = plot(xlabel="current assets", ylabel="next period assets",
+           legend=:topleft)
+for (z_i, z) in enumerate(hh.z_grid)
+    plot!(plt, hh.a_vals,
+          [(1 + hh.r) * pf((a, z)) + y_bar(z_i) for a in hh.a_vals],
+          label="z = " * string(round(z, digits=2)))
+end
+plot!(plt, hh.a_vals, hh.a_vals, linestyle=:dash, color=:black,
+      label="45 degrees")
+
+# stationary wealth distribution
+mc = markov_chain(res)
+stat = stationary_distributions(mc)[1]
+a_of_state = first.(mc.state_values)
+keep = stat .> 1e-9
+histogram(a_of_state[keep], weights=stat[keep], bins=60, normalize=:pdf,
+          xlabel="assets", ylabel="density")
+
+# the POMDPs idiom end to end: same model, ecosystem vocabulary
+policy = POMDPs.solve(DiscreteDPSolver(PFI), hh)
+s0 = (hh.a_vals[41], hh.z_grid[2])
+println("action(policy, s0) = ", round(action(policy, s0), digits=3),
+        ", value(policy, s0) = ", round(value(policy, s0), digits=3))
+for step in stepthrough(hh, policy, s0, "s,a,r", max_steps=5)
+    println("a = ", round(step.s[1], digits=3), "  ->  sav = ",
+            round(step.a, digits=3), "  r = ", round(step.r, digits=3))
+end

--- a/src/QuantEcon.jl
+++ b/src/QuantEcon.jl
@@ -132,8 +132,9 @@ export
     DiscreteDP, VFI, PFI, MPFI, solve, RQ_sigma,
     evaluate_policy, bellman_operator, compute_greedy,
     bellman_operator!, num_states, backward_induction,
-    num_sa_pairs, to_sa_pair_form, to_product_form,
+    num_sa_pairs, to_sa_pair_form, to_product_form, markov_chain,
     sigma_values, state_to_index, DDPPolicyFunction, DDPValueFunction,
+    DiscreteDPSolver,
 
 # zeros / optimization
     bisect, brenth, brent, ridder, expand_bracket, divide_bracket,
@@ -184,5 +185,15 @@ include("pivoting.jl")
 include("lcp_lemke.jl")
 include("modeltools/utility.jl")
 include("modeltools/types.jl")
+
+function __init__()
+    Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, kwargs
+        if exc.f === DiscreteDPSolver
+            print(io, "\nDiscreteDPSolver is provided by the POMDPs.jl " *
+                "integration: load both POMDPs and POMDPTools " *
+                "(`using POMDPs, POMDPTools`) to enable it.")
+        end
+    end
+end
 
 end # module

--- a/src/markov/ddp.jl
+++ b/src/markov/ddp.jl
@@ -894,6 +894,26 @@ QuantEcon.MarkovChain(ddp::DiscreteDP, sigma::AbstractVector{<:Integer}) =
     MarkovChain(RQ_sigma(ddp, sigma)[2], ddp.state_values)
 
 """
+    markov_chain(res)
+
+Return the controlled Markov chain of a solved model, `res.mc`: the
+chain induced by the optimal policy, computed at the end of `solve` and
+carrying `res.ddp.state_values`. It is returned by reference, not
+copied, and is not recomputed from the current contents of `res.sigma`
+(for that, use `MarkovChain(ddp, sigma)`).
+
+# Arguments
+
+- `res::DPSolveResult`: Object that contains result variables.
+
+# Returns
+
+- `mc::MarkovChain`: Controlled Markov chain.
+
+"""
+markov_chain(res::DPSolveResult) = res.mc
+
+"""
     sigma_values(res)
 
 Return the optimal policy decoded to action values,
@@ -1084,6 +1104,17 @@ function DDPValueFunction(res::DPSolveResult;
 end
 
 (vf::DDPValueFunction)(s) = vf.v[vf.im[s]]
+
+"""
+    DiscreteDPSolver
+
+Solver for POMDPs.jl models based on the `DiscreteDP` solution methods,
+constructed as `DiscreteDPSolver(algo; max_iter, epsilon, k)` with
+`algo` one of `VFI` (the default), `PFI`, or `MPFI` and the keyword
+options of `solve`. Provided by the POMDPs.jl integration: load both
+POMDPs and POMDPTools (`using POMDPs, POMDPTools`) to enable it.
+"""
+function DiscreteDPSolver end
 
 """
     RQ_sigma(ddp, sigma)

--- a/src/markov/ddp.jl
+++ b/src/markov/ddp.jl
@@ -1109,10 +1109,12 @@ end
     DiscreteDPSolver
 
 Solver for POMDPs.jl models based on the `DiscreteDP` solution methods,
-constructed as `DiscreteDPSolver(algo; max_iter, epsilon, k)` with
-`algo` one of `VFI` (the default), `PFI`, or `MPFI` and the keyword
-options of `solve`. Provided by the POMDPs.jl integration: load both
-POMDPs and POMDPTools (`using POMDPs, POMDPTools`) to enable it.
+constructed as `DiscreteDPSolver(algo; sparse, max_iter, epsilon, k)`
+with `algo` one of `VFI` (the default), `PFI`, or `MPFI`, `sparse` the
+value-typed tabulation-formulation flag (`Val(true)` by default), and
+the remaining keyword options those of `solve`. Provided by the
+POMDPs.jl integration: load both POMDPs and POMDPTools
+(`using POMDPs, POMDPTools`) to enable it.
 """
 function DiscreteDPSolver end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,6 +39,10 @@ tests = [
         "interp",
         "sampler",
         "util",
+        # must be LAST: loads POMDPs/POMDPTools, which makes bare
+        # `solve`/`simulate` ambiguous for later files and activates
+        # the extension (test_ddp.jl tests the method-less stub)
+        "pomdps",
         ]
 
 

--- a/test/test_ddp.jl
+++ b/test/test_ddp.jl
@@ -866,6 +866,23 @@ Tests for markov/ddp.jl
             @test_throws ArgumentError DDPValueFunction(_res; im=_bad)
         end
 
+        @testset "markov_chain and DiscreteDPSolver stub" begin
+            _res = solve(ddp0, PFI)
+            @test (@inferred markov_chain(_res)) === _res.mc
+
+            # the stub has no methods until the POMDPs extension is
+            # loaded, and its MethodError carries the hint; this relies
+            # on test_pomdps.jl (which loads POMDPs) running last
+            @test DiscreteDPSolver isa Function
+            _err = try
+                DiscreteDPSolver()
+            catch _e
+                _e
+            end
+            @test _err isa MethodError
+            @test occursin("POMDPTools", sprint(showerror, _err))
+        end
+
         @testset "duplicated values: decoration yes, inversion no" begin
             # repeated action labels are legal (shared display names)
             _ddp_a = DiscreteDP(R, Q, beta; action_values=[:stay, :stay])

--- a/test/test_pomdps.jl
+++ b/test/test_pomdps.jl
@@ -1,0 +1,160 @@
+#=
+Tests for the POMDPs.jl extension (ext/QuantEconPOMDPsExt.jl)
+
+NOTE: this file must run LAST: `using POMDPs` makes the bare names
+`solve` and `simulate` ambiguous in Main for every subsequently
+included test file, and loading the extension gives the
+`DiscreteDPSolver` stub methods (test_ddp.jl tests the method-less
+stub). All `solve` calls below are qualified.
+=#
+
+using POMDPs
+using POMDPTools
+
+@testset "Testing ext/QuantEconPOMDPsExt.jl" begin
+
+    ext = Base.get_extension(QuantEcon, :QuantEconPOMDPsExt)
+    @test ext !== nothing
+    as_mdp = ext.as_mdp
+
+    # Puterman fixture (as in test_ddp.jl); action 2 infeasible in state 2
+    beta_p = 0.95
+    R_p = [5.0 10.0; -1.0 -Inf]
+    Q_p = Array{Float64}(undef, 2, 2, 2)
+    Q_p[:, :, 1] = [0.5 0.0; 0.0 0.0]
+    Q_p[:, :, 2] = [0.5 1.0; 1.0 1.0]
+    ddp0 = DiscreteDP(R_p, Q_p, beta_p)
+    ddp0_sa = to_sa_pair_form(ddp0)
+
+    # test model exercising state-dependent actions, a terminal state,
+    # and (s, a, sp)-only rewards; enumerates in index order so that
+    # SparseTabularMDP's ordering coincides with the importer's
+    struct TestMDP <: POMDPs.MDP{Int,Int} end
+    POMDPs.states(::TestMDP) = 1:3
+    POMDPs.actions(::TestMDP) = 1:2
+    POMDPs.actions(::TestMDP, s::Int) = s == 2 ? (1:1) : (1:2)
+    POMDPs.stateindex(::TestMDP, s::Int) = s
+    POMDPs.actionindex(::TestMDP, a::Int) = a
+    POMDPs.discount(::TestMDP) = 0.9
+    POMDPs.isterminal(::TestMDP, s::Int) = s == 3
+    POMDPs.initialstate(::TestMDP) = Deterministic(1)
+    POMDPs.transition(::TestMDP, s::Int, a::Int) =
+        a == 1 ? SparseCat([1, 2], [0.7, 0.3]) : SparseCat([3], [1.0])
+    POMDPs.reward(::TestMDP, s::Int, a::Int, sp::Int) = s + 0.5a + 0.25sp
+
+    @testset "importer: structure and values" begin
+        _ddp = DiscreteDP(TestMDP())
+        @test _ddp.state_values == [1, 2, 3]
+        @test _ddp.action_values == [1, 2]
+        @test _ddp.beta == 0.9
+        # pairs: s1 x {1,2}, s2 x {1}, s3 terminal x {1,2}
+        @test _ddp.s_indices == [1, 1, 2, 3, 3]
+        @test _ddp.a_indices == [1, 2, 1, 1, 2]
+        # expected rewards under the transition; 0 at the terminal state
+        @test _ddp.R[1] ≈ 1 + 0.5 + 0.25 * (0.7 * 1 + 0.3 * 2)
+        @test _ddp.R[2] ≈ 1 + 1.0 + 0.25 * 3
+        @test _ddp.R[3] ≈ 2 + 0.5 + 0.25 * (0.7 * 1 + 0.3 * 2)
+        @test _ddp.R[4] == 0.0
+        @test _ddp.R[5] == 0.0
+        # terminal self-loops
+        @test Matrix(_ddp.Q)[4, :] == [0.0, 0.0, 1.0]
+        @test Matrix(_ddp.Q)[5, :] == [0.0, 0.0, 1.0]
+
+        # terminal state has value exactly zero
+        _res = QuantEcon.solve(_ddp, PFI)
+        @test _res.v[3] == 0.0
+    end
+
+    @testset "importer: cross-validation against SparseTabularMDP" begin
+        _m = TestMDP()
+        _stm = SparseTabularMDP(_m)
+        _pf = to_product_form(DiscreteDP(_m))
+        @test _pf.R == _stm.R
+        for _a in 1:2
+            @test _pf.Q[:, _a, :] ≈ Matrix(_stm.T[_a])
+        end
+    end
+
+    @testset "importer: validation" begin
+        # duplicated states are rejected at tabulation
+        struct DupMDP <: POMDPs.MDP{Int,Int} end
+        POMDPs.states(::DupMDP) = [1, 1]
+        @test_throws ArgumentError DiscreteDP(DupMDP())
+
+        # transitions must stay inside states(m)
+        struct LeakyMDP <: POMDPs.MDP{Int,Int} end
+        POMDPs.states(::LeakyMDP) = 1:2
+        POMDPs.actions(::LeakyMDP) = 1:1
+        POMDPs.discount(::LeakyMDP) = 0.9
+        POMDPs.transition(::LeakyMDP, s::Int, a::Int) = Deterministic(99)
+        POMDPs.reward(::LeakyMDP, s::Int, a::Int, sp::Int) = 0.0
+        _err = try
+            DiscreteDP(LeakyMDP())
+        catch _e
+            _e
+        end
+        @test _err isa ArgumentError
+        @test occursin("closed under transitions", _err.msg)
+    end
+
+    @testset "round trip: native -> as_mdp -> importer" begin
+        seed = 1234
+        _rng = MersenneTwister(seed)
+        _random = random_discrete_dp(_rng, 5, 3)
+        for _ddp in (ddp0,                              # dense with -Inf
+                     ddp0_sa,                           # SA sparse
+                     _random,                           # random dense
+                     to_sa_pair_form(_random))          # random SA sparse
+            _res = QuantEcon.solve(_ddp, PFI)
+            _res_rt = QuantEcon.solve(DiscreteDP(as_mdp(_ddp)), PFI)
+            @test _res_rt.sigma == _res.sigma
+            @test _res_rt.v ≈ _res.v
+        end
+    end
+
+    @testset "as_mdp interface" begin
+        _w = as_mdp(ddp0)
+        @test collect(states(_w)) == [1, 2]
+        @test collect(actions(_w)) == [1, 2]
+        @test collect(actions(_w, 1)) == [1, 2]
+        @test collect(actions(_w, 2)) == [1]        # -Inf pair omitted
+        @test reward(_w, 1, 2) == 10.0
+        _d = transition(_w, 1, 1)
+        @test sum(_d.probs) ≈ 1.0
+        @test isterminal(_w, 1) == false
+        @test discount(_w) == beta_p
+        @test_throws ArgumentError reward(_w, 2, 2)  # infeasible pair
+    end
+
+    @testset "DiscreteDPSolver and DiscreteDPPolicy" begin
+        _m = as_mdp(ddp0)
+        _res = QuantEcon.solve(ddp0, PFI)
+
+        # via the core generic (the exported name users call)
+        _solver = DiscreteDPSolver(PFI; max_iter=137, epsilon=1e-4, k=17)
+        @test _solver isa POMDPs.Solver
+        _policy = POMDPs.solve(_solver, _m)
+        for (_i, _s) in enumerate(states(_m))
+            @test action(_policy, _s) == sigma_values(_res)[_i]
+            @test value(_policy, _s) == _res.v[_i]
+        end
+
+        # options are recorded in the wrapped native result
+        @test _policy.res.max_iter == 137
+        @test _policy.res.epsilon == 1e-4
+        @test _policy.res.k == 17
+        @test _policy.m === _m
+
+        # markov_chain: uniform accessor over results and policies
+        @test markov_chain(_policy) === _policy.res.mc
+        @test markov_chain(_policy.res) === _policy.res.mc
+
+        # zero-argument default mirrors native solve (VFI)
+        _default = DiscreteDPSolver()
+        @test _default isa POMDPs.Solver
+        _policy_d = POMDPs.solve(_default, _m)
+        @test _policy_d.res isa QuantEcon.DPSolveResult{VFI}
+        @test _policy_d.res.max_iter == 250
+    end
+
+end

--- a/test/test_pomdps.jl
+++ b/test/test_pomdps.jl
@@ -65,6 +65,34 @@ using POMDPTools
         @test _res.v[3] == 0.0
     end
 
+    @testset "importer and solver: sparse option" begin
+        _dt = DiscreteDP(TestMDP())                     # default: SA sparse
+        @test issparse(_dt.Q)
+        _dd = DiscreteDP(TestMDP(); sparse=Val(false))  # dense product form
+        @test _dd.Q isa Array{Float64,3}
+        @test size(_dd.R) == (3, 2)
+        @test _dd.R[2, 2] == -Inf                       # infeasible pair
+        # the direct dense construction equals the compositional route
+        _pf = to_product_form(_dt)
+        @test _dd.R == _pf.R
+        @test _dd.Q == _pf.Q
+        _r_s = QuantEcon.solve(_dt, PFI)
+        _r_d = QuantEcon.solve(_dd, PFI)
+        @test _r_d.sigma == _r_s.sigma
+        @test _r_d.v ≈ _r_s.v
+
+        # the flag is a type parameter of the solver and reaches the
+        # tabulation
+        _m = as_mdp(ddp0)
+        _pol_d = POMDPs.solve(DiscreteDPSolver(PFI; sparse=Val(false)), _m)
+        @test _pol_d.res.ddp.Q isa Array{Float64,3}
+        _pol_s = POMDPs.solve(DiscreteDPSolver(PFI), _m)
+        @test issparse(_pol_s.res.ddp.Q)
+        for _s in states(_m)
+            @test action(_pol_d, _s) == action(_pol_s, _s)
+        end
+    end
+
     @testset "importer: cross-validation against SparseTabularMDP" begin
         _m = TestMDP()
         _stm = SparseTabularMDP(_m)

--- a/test/test_pomdps.jl
+++ b/test/test_pomdps.jl
@@ -65,6 +65,42 @@ using POMDPTools
         @test _res.v[3] == 0.0
     end
 
+    @testset "importer: terminal state with empty actions(m, s)" begin
+        # natural POMDPs.jl idiom: no feasible action at a terminal
+        # state; the terminal encoding must not depend on actions(m, s)
+        struct EmptyTermMDP <: POMDPs.MDP{Int,Int} end
+        POMDPs.states(::EmptyTermMDP) = 1:2
+        POMDPs.actions(::EmptyTermMDP) = 1:2
+        POMDPs.actions(m::EmptyTermMDP, s::Int) =
+            POMDPs.isterminal(m, s) ? () : (1:2)
+        POMDPs.discount(::EmptyTermMDP) = 0.9
+        POMDPs.isterminal(::EmptyTermMDP, s::Int) = s == 2
+        POMDPs.transition(::EmptyTermMDP, s::Int, a::Int) =
+            a == 1 ? SparseCat([1, 2], [0.6, 0.4]) : Deterministic(2)
+        POMDPs.reward(::EmptyTermMDP, s::Int, a::Int, sp::Int) = 1.0
+
+        # sparse: self-loop pairs for every global action
+        _dt = DiscreteDP(EmptyTermMDP())
+        @test _dt.s_indices == [1, 1, 2, 2]
+        @test _dt.a_indices == [1, 2, 1, 2]
+        @test _dt.R[3] == _dt.R[4] == 0.0
+        @test Matrix(_dt.Q)[3, :] == [0.0, 1.0]
+        @test Matrix(_dt.Q)[4, :] == [0.0, 1.0]
+
+        # dense: full zero-reward row with self-loops
+        _dd = DiscreteDP(EmptyTermMDP(); sparse=Val(false))
+        @test _dd.R[2, :] == [0.0, 0.0]
+        @test _dd.Q[2, 1, :] == [0.0, 1.0]
+        @test _dd.Q[2, 2, :] == [0.0, 1.0]
+
+        # both forms solve, agree, and give the terminal state value 0
+        _r_s = QuantEcon.solve(_dt, PFI)
+        _r_d = QuantEcon.solve(_dd, PFI)
+        @test _r_s.v[2] == 0.0
+        @test _r_d.sigma == _r_s.sigma
+        @test _r_d.v ≈ _r_s.v
+    end
+
     @testset "importer and solver: sparse option" begin
         _dt = DiscreteDP(TestMDP())                     # default: SA sparse
         @test issparse(_dt.Q)


### PR DESCRIPTION
Close #398

This PR adds the package extension `QuantEconPOMDPsExt` connecting our `DiscreteDP` to the JuliaPOMDP ecosystem.
* [`POMDPs.jl`](https://github.com/JuliaPOMDP/POMDPs.jl) is a package that provides a core interface for working with MDPs (Markov decision processes) and POMDPs (partially observable Markov decision processes). (`DiscreteDP` is a finite MDP.)
* `POMDPs` and `POMDPTools` are added as *weak dependencies* (weakdeps).
* The extension `QuantEconPOMDPsExt` is activated only with `using POMDPs, POMDPTools`.
* The change is purely additive: no existing behavior changes.

## Features

### Modeling interface

This allows us to use the POMDPs.jl interface as a simple interface for specifying a `DiscreteDP` model (see also QuantEcon/QuantEcon.py#228). As an example, consider the Aiyagari model as described in https://julia.quantecon.org/multi_agent_models/aiyagari.html (compare the corresponding script in #402):

```julia
using QuantEcon, POMDPs, POMDPTools

# Model specification as a subtype of POMDPs.MDP{S,A}
struct Household{TZ<:MarkovChain,TA<:AbstractVector,TU} <:
        POMDPs.MDP{Tuple{Float64,Float64},Float64}
    r::Float64
    w::Float64
    sigma::Float64
    beta::Float64
    z_chain::TZ
    a_vals::TA
    u::TU
end

function Household(; r = 0.01,
                   w = 1.0,
                   sigma = 1.0,
                   beta = 0.96,
                   z_chain = MarkovChain([0.9 0.1; 0.1 0.9], [0.1; 1.0]),
                   a_min = 1e-10,
                   a_max = 18.0,
                   a_size = 200,
                   a_vals = range(a_min, a_max, length = a_size),
                   u = sigma == 1 ? x -> log(x) :
                       x -> (x^(1 - sigma) - 1) / (1 - sigma))
    return Household(r, w, sigma, beta, z_chain, a_vals, u)
end

# The POMDPs.jl interface
POMDPs.states(am::Household) =
    Iterators.product(am.a_vals, am.z_chain.state_values)
POMDPs.actions(am::Household) = am.a_vals
POMDPs.actions(am::Household, (a, z)::Tuple) =
    (a_new for a_new in am.a_vals if am.w * z + (1 + am.r) * a - a_new > 0)
POMDPs.reward(am::Household, (a, z)::Tuple, a_new) =
    am.u(am.w * z + (1 + am.r) * a - a_new)
POMDPs.transition(am::Household, (a, z)::Tuple, a_new) =
    SparseCat([(a_new, z_new) for z_new in am.z_chain.state_values],
              am.z_chain.p[findfirst(==(z), am.z_chain.state_values), :])
POMDPs.discount(am::Household) = am.beta

am = Household(; a_max = 20.0, r = 0.03, w = 0.956)

# A native DiscreteDP can be constructed from a POMDPs.MDP model
am_ddp = DiscreteDP(am)
results = QuantEcon.solve(am_ddp, PFI)

# The rest is the same as in #402
a_vals = am.a_vals
z_vals = am.z_chain.state_values
pf = DDPPolicyFunction(results)               # (a, z) -> next period assets
a_star = [pf((a, z)) for a in a_vals, z in z_vals]

# To obtain the controlled MarkovChain
mc = markov_chain(results)  # or mc = results.mc
K = sum(stationary_distributions(mc)[1] .* first.(mc.state_values))
```

### Joining the JuliaPOMDP ecosystem

This extension exposes our solution methods through a `POMDPs.Solver` (`DiscreteDPSolver`), so we can use tools from the JuliaPOMDP ecosystem to work with the model and the computed policy.

```julia
# Household defined as above
am = Household(; a_max = 20.0, r = 0.03, w = 0.956)

# Our `POMDPs.Solver`
solver = DiscreteDPSolver(PFI)     # solver isa POMDPs.Solver
policy = POMDPs.solve(solver, am)  # policy isa POMDPs.Policy

# queries
a_vals = am.a_vals
z_vals = am.z_chain.state_values
s = (a_vals[117], z_vals[2])            # (a, z) ≈ (11.658, 1.0)
action(policy, s)                       # sigma(a, z)
value(policy, s)                        # v(a, z)

a_star = [action(policy, (a, z)) for a in a_vals, z in z_vals]  # same table as above

# To obtain the controlled MarkovChain
mc = markov_chain(policy)
K = sum(stationary_distributions(mc)[1] .* first.(mc.state_values))
```

See "[Interacting with Policies](https://juliapomdp.github.io/POMDPs.jl/stable/policy_interaction/)" in the POMDPs.jl documentation for details on working with the `policy` object, and "[Implemented Simulators](https://juliapomdp.github.io/POMDPs.jl/stable/POMDPTools/simulators/)" for the tools that consume it (note `simulate`, like `solve`, must be qualified as `POMDPs.simulate`).
The native `DPSolveResult` remains reachable as `policy.res`.

## Questions

1. Do we allow this package extension, with `POMDPs` and `POMDPTools` as weakdeps?
2. This PR will in effect have our `DiscreteDP` join the JuliaPOMDP ecosystem. Are we comfortable with that?